### PR TITLE
Add test failing because decapsulate is based on substrings.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,19 @@ impl Multiaddr {
     }
 }
 
+#[test]
+fn decapsulate_no_substring() {
+    // 01e0:: -> [1, 224, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    // and [1, 224] is the code for HTTP
+    let addr = Multiaddr::new("/ip6/01e0::/http/example.com").unwrap();
+    let http = Multiaddr::new("/http").unwrap();
+    println!("{:?}", addr);
+    println!("{:?}", http);
+    let decaps = addr.decapsulate(http).unwrap();
+    println!("{:?}", decaps);
+    println!("{}", decaps.to_string());
+}
+
 
 /// A trait for objects which can be converted to a
 /// Multiaddr.


### PR DESCRIPTION
`decapsulate` uses a substring matching technique to find the subaddress to be removed.
However, there is no safeguard for this substring to be part of content before the subaddress, eg. an IP address.

This PR adds a test that crashes if the vulnerability exist:

```


I am not sending a fix right now, because I think the best way to fix that would be to change the internal structure of Multiaddr. See issue #18.