### PR TITLE
Replace varmint with integer-encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.0"
 [dependencies]
 byteorder = "~0.4"
 cid = "~0.2"
-varmint = "0.1.2"
+integer-encoding = "~1.0.3"
 
 [dev-dependencies]
 data-encoding = "~1.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 ///! in Rust.
 extern crate byteorder;
 extern crate cid;
-extern crate varmint;
+extern crate integer_encoding;
 
 mod protocol;
 mod parser;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@ use std::convert::From;
 use std::io::Cursor;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use cid::Cid;
-use varmint::WriteVarInt;
+use integer_encoding::VarIntWriter;
 
 use {Result, Error};
 
@@ -167,7 +167,7 @@ impl Protocol {
             IPFS => {
                 let bytes = Cid::from(a)?.to_bytes();
                 let mut res = vec![];
-                res.write_u64_varint(bytes.len() as u64)?;
+                res.write_varint(bytes.len())?;
                 res.extend(bytes);
 
                 Ok(res)


### PR DESCRIPTION
Same reasoning as `rust-cid`.