### PR TITLE
Define and use parsed address segment representation inside `Multiaddr` instead of `Vec<u8>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 version = "0.2.0"
 
 [dependencies]
-byteorder = "~0.4"
+byteorder = "~1.1"
 cid = "~0.2"
 integer-encoding = "~1.0.3"
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,5 @@
 use std::{net, fmt, error, io, num};
 use cid;
-use byteorder;
 
 pub type Result<T> = ::std::result::Result<T, Error>;
 
@@ -48,12 +47,6 @@ impl From<cid::Error> for Error {
 
 impl From<net::AddrParseError> for Error {
     fn from(_: net::AddrParseError) -> Error {
-        Error::ParsingError
-    }
-}
-
-impl From<byteorder::Error> for Error {
-    fn from(_: byteorder::Error) -> Error {
         Error::ParsingError
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,14 @@ mod parser;
 mod errors;
 
 pub use errors::{Result, Error};
-pub use protocol::{Protocol, Addr, AddressSegment, AddressSegmentReaderExt, AddressSegmentWriterExt};
+pub use protocol::{Protocol, Segment, AddressSegment, AddressSegmentReaderExt, AddressSegmentWriterExt};
 
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr};
 
 /// Representation of a Multiaddr.
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct Multiaddr {
-    addr: Vec<Addr>,
+    addr: Vec<Segment>,
 
     #[deprecated]
     bytes: Vec<u8>
@@ -66,7 +66,7 @@ impl Multiaddr {
         Ok(Multiaddr { bytes: Self::_addr_to_bytes(&addr), addr: addr })
     }
 
-    fn _addr_to_bytes(addr: &Vec<Addr>) -> Vec<u8> {
+    fn _addr_to_bytes(addr: &Vec<Segment>) -> Vec<u8> {
         let mut bytes = Vec::new();
         for addr_segment in addr {
             addr_segment.to_stream(&mut bytes).unwrap();
@@ -114,10 +114,10 @@ impl Multiaddr {
     /// use multiaddr::{Multiaddr, protocol};
     ///
     /// let address = Multiaddr::new("/ip4/127.0.0.1").unwrap();
-    /// assert_eq!(address.segments(), [protocol::Addr::IP4(protocol::IP4Addr(Ipv4Addr::new(127, 0, 0, 1)))]);
+    /// assert_eq!(address.segments(), [protocol::Segment::IP4(protocol::IP4Segment(Ipv4Addr::new(127, 0, 0, 1)))]);
     /// ```
     ///
-    pub fn segments(&self) -> &[Addr] {
+    pub fn segments(&self) -> &[Segment] {
         &self.addr
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,12 @@ extern crate byteorder;
 extern crate cid;
 extern crate integer_encoding;
 
-mod protocol;
+pub mod protocol;
 mod parser;
 mod errors;
 
 pub use errors::{Result, Error};
-pub use protocol::Protocol;
+pub use protocol::{Protocol, Addr, AddressSegment, AddressSegmentReaderExt, AddressSegmentWriterExt};
 
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use std::fmt::Write;
 
-use protocol::{Segment, AddressSegment, Protocol};
+use protocol::{Segment, Protocol};
 use {Result, Error};
 
 pub fn multiaddr_from_str(input: &str) -> Result<Vec<Segment>> {
@@ -37,11 +37,7 @@ pub fn multiaddr_to_str(addr: &Vec<Segment>) -> String {
 
     for addr_segment in addr {
         result.push('/');
-        result.push_str(addr_segment.protocol().as_str());
-
-        if addr_segment.protocol().size() != 0 {
-            write!(result, "/{}", addr_segment).unwrap();
-        }
+        write!(result, "{}", addr_segment).unwrap();
     }
 
     result

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,102 +1,48 @@
 use std::str::FromStr;
+use std::fmt::Write;
 
-use integer_encoding::{VarInt, VarIntWriter};
-
-use protocol::Protocol;
+use protocol::{Addr, AddressSegment, Protocol};
 use {Result, Error};
 
-pub fn multiaddr_from_str(input: &str) -> Result<Vec<u8>> {
-    // drdop trailing slashes
+pub fn multiaddr_from_str(input: &str) -> Result<Vec<Addr>> {
+    // Drop trailing slashes then split address into segment parts
     let input = input.trim_right_matches('/');
-
-    let mut bytes = vec![];
     let mut parts = input.split('/');
-    let next = parts.next().ok_or(Error::InvalidMultiaddr)?;
 
-    if !next.is_empty() {
+    // Expect address to start with just a slash ('/')
+    let first = parts.next().ok_or(Error::InvalidMultiaddr)?;
+    if !first.is_empty() {
         return Err(Error::InvalidMultiaddr);
     }
 
+    let mut multiaddr = Vec::with_capacity(input.split('/').count());
     while let Some(n) = parts.next() {
+        // Determine segment protocol number and possible extra data
         let p = Protocol::from_str(n)?;
-
-        bytes.write_varint(p as u64)?;
-
-        if p.size() == 0 {
-            continue;
-        }
-
-        let next = match parts.next() {
-            Some(path) => path,
-            None => return Err(Error::MissingAddress),
+        let s = match p.size() {
+            0 => &"",
+            _ => parts.next().ok_or(Error::MissingAddress)?
         };
 
-        bytes.extend(p.string_to_bytes(next)?);
+        // Parse and store segment data
+        multiaddr.push(Addr::from_protocol_str(p, s)?);
     }
 
-    Ok(bytes)
-}
-
-fn read_varint_code(input: &[u8]) -> Result<(u64, usize)> {
-    let res = u64::decode_var(input);
-
-    if res.0 == 0 {
-        return Err(Error::ParsingError)
-    }
-
-    Ok(res)
-}
-
-fn size_for_addr(protocol: Protocol, input: &[u8]) -> Result<(usize, usize)> {
-    if protocol.size() > 0 {
-        Ok((protocol.size() as usize / 8, 0))
-    } else if protocol.size() == 0 {
-        Ok((0, 0))
-    } else {
-        let (size, n) = read_varint_code(input)?;
-        Ok((size as usize, n))
-    }
-}
-
-pub fn protocol_from_bytes(input: &[u8]) -> Result<Vec<Protocol>> {
-    let mut ps = vec![];
-    let mut i = 0;
-
-    while i < input.len() {
-        let (code, n) = read_varint_code(&input[i..])?;
-        let p = Protocol::from(code)?;
-        ps.push(p);
-
-        i += n;
-        let (size, adv) = size_for_addr(p, &input[i..])?;
-        i += size + adv;
-    }
-
-    Ok(ps)
+    Ok(multiaddr)
 }
 
 
-pub fn address_from_bytes(input: &[u8]) -> Result<String> {
-    let mut protos = vec!["".to_string()];
-    let mut i = 0;
+pub fn multiaddr_to_str(addr: &Vec<Addr>) -> String {
+    let mut result = String::new();
 
-    while i < input.len() {
+    for addr_segment in addr {
+        result.push('/');
+        result.push_str(addr_segment.protocol().as_str());
 
-        let (code, n) = read_varint_code(&input[i..])?;
-        i += n;
-
-        let p = Protocol::from(code)?;
-        protos.push(p.to_string());
-
-        let (size, adv) = size_for_addr(p, &input[i..])?;
-        i += adv;
-
-        if let Some(s) = p.bytes_to_string(&input[i..i + size])? {
-            protos.push(s);
+        if addr_segment.protocol().size() != 0 {
+            write!(result, "/{}", addr_segment).unwrap();
         }
-
-        i += size;
     }
 
-    Ok(protos.join("/"))
+    result
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 use std::fmt::Write;
 
-use protocol::{Addr, AddressSegment, Protocol};
+use protocol::{Segment, AddressSegment, Protocol};
 use {Result, Error};
 
-pub fn multiaddr_from_str(input: &str) -> Result<Vec<Addr>> {
+pub fn multiaddr_from_str(input: &str) -> Result<Vec<Segment>> {
     // Drop trailing slashes then split address into segment parts
     let input = input.trim_right_matches('/');
     let mut parts = input.split('/');
@@ -25,14 +25,14 @@ pub fn multiaddr_from_str(input: &str) -> Result<Vec<Addr>> {
         };
 
         // Parse and store segment data
-        multiaddr.push(Addr::from_protocol_str(p, s)?);
+        multiaddr.push(Segment::from_protocol_str(p, s)?);
     }
 
     Ok(multiaddr)
 }
 
 
-pub fn multiaddr_to_str(addr: &Vec<Addr>) -> String {
+pub fn multiaddr_to_str(addr: &Vec<Segment>) -> String {
     let mut result = String::new();
 
     for addr_segment in addr {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -205,7 +205,7 @@ impl AddressSegment for TCPSegment {
     }
 
     fn to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
-        Ok(stream.write_u16::<BigEndian>(self.0)?)
+        stream.write_u16::<BigEndian>(self.0)
     }
 }
 
@@ -227,7 +227,7 @@ impl AddressSegment for UDPSegment {
     }
 
     fn to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
-        Ok(stream.write_u16::<BigEndian>(self.0)?)
+        stream.write_u16::<BigEndian>(self.0)
     }
 }
 
@@ -249,7 +249,7 @@ impl AddressSegment for DCCPSegment {
     }
 
     fn to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
-        Ok(stream.write_u16::<BigEndian>(self.0)?)
+        stream.write_u16::<BigEndian>(self.0)
     }
 }
 
@@ -307,7 +307,7 @@ impl AddressSegment for SCTPSegment {
     }
 
     fn to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
-        Ok(stream.write_u16::<BigEndian>(self.0)?)
+        stream.write_u16::<BigEndian>(self.0)
     }
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -510,10 +510,7 @@ macro_rules! build_enums {
 
         impl ToString for Protocol {
             fn to_string(&self) -> String {
-                match *self {
-                    $( Protocol::$var => $alph.to_string(), )*
-                    _ => unreachable!()
-                }
+                self.as_str().to_string()
             }
         }
 
@@ -560,6 +557,15 @@ macro_rules! build_enums {
             pub fn size(&self) -> isize {
                 match *self {
                     $( Protocol::$var => $size, )*
+                    _ => unreachable!()
+                }
+            }
+
+            /// Obtain the name of this protocol variant as an human-readable
+            /// string
+            pub fn as_str(&self) -> &str {
+                match *self {
+                    $( Protocol::$var => $alph, )*
                     _ => unreachable!()
                 }
             }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -486,7 +486,7 @@ derive_for_empty_addr!(Libp2pWebrtcDirectAddr: Display, FromStr, Addr<Libp2pWebr
 
 
 macro_rules! build_enums {
-    { $( $val:expr => $var:ident ( $alph:expr, $size:expr ) for $addr_type:ident ),* } => {
+    { $( $val:expr => $var:ident ( $alph:expr ) for $addr_type:ident ),* } => {
         /// Protocol is the list of all possible protocols.
         //XXX: #[non_exhaustive] is not stable yet
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -544,7 +544,16 @@ macro_rules! build_enums {
                 }
             }
 
-            /// Get the size from a `Protocol`.
+            /// Get the estimated size of the binary representation of this
+            /// `Protocol` in bits.
+            ///
+            /// Note the values are only estimates and calling `.to_stream()`
+            /// on a corresponding `Addr` instance may result in a buffer of a
+            /// different size. The only noteworthy execption is a returned
+            /// value of `0` which guarantees that the given protocol will
+            /// never expect a value parameter and will never read or write
+            /// anything when being asked to process serialize/deserialize
+            /// itself.
             ///
             /// # Examples
             ///
@@ -556,7 +565,7 @@ macro_rules! build_enums {
             ///
             pub fn size(&self) -> isize {
                 match *self {
-                    $( Protocol::$var => $size, )*
+                    $( Protocol::$var => ($addr_type::STREAM_LENGTH * 8) as isize, )*
                     _ => unreachable!()
                 }
             }
@@ -659,36 +668,36 @@ macro_rules! build_enums {
 
 build_enums!(
     // [IP4](https://en.wikipedia.org/wiki/IPv4)
-    4 => IP4("ip4", 32) for IP4Addr,
+    4 => IP4("ip4") for IP4Addr,
     // [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol)
-    6 => TCP("tcp", 16) for TCPAddr,
+    6 => TCP("tcp") for TCPAddr,
     // [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol)
-    17 => UDP("udp", 16) for UDPAddr,
+    17 => UDP("udp") for UDPAddr,
     // [DCCP](https://en.wikipedia.org/wiki/Datagram_Congestion_Control_Protocol)
-    33 => DCCP("dccp", 16) for DCCPAddr,
+    33 => DCCP("dccp") for DCCPAddr,
     // [IP6](https://en.wikipedia.org/wiki/IPv6)
-    41 => IP6("ip6", 128) for IP6Addr,
+    41 => IP6("ip6") for IP6Addr,
     // [SCTP](https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol)
-    132 => SCTP("sctp", 16) for SCTPAddr,
+    132 => SCTP("sctp") for SCTPAddr,
     // [UDT](https://en.wikipedia.org/wiki/UDP-based_Data_Transfer_Protocol)
-    301 => UDT("udt", 0) for UDTAddr,
+    301 => UDT("udt") for UDTAddr,
     // [UTP](https://en.wikipedia.org/wiki/Micro_Transport_Protocol)
-    302 => UTP("utp", 0) for UTPAddr,
+    302 => UTP("utp") for UTPAddr,
     // [IPFS](https://github.com/ipfs/specs/tree/master/protocol#341-merkledag-paths)
-    421 => IPFS("ipfs", -1) for IPFSAddr,
+    421 => IPFS("ipfs") for IPFSAddr,
     // [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)
-    480 => HTTP("http", 0) for HTTPAddr,
+    480 => HTTP("http") for HTTPAddr,
     // [HTTPS](https://en.wikipedia.org/wiki/HTTPS)
-    443 => HTTPS("https", 0) for HTTPSAddr,
+    443 => HTTPS("https") for HTTPSAddr,
     // Onion
-    444 => Onion("onion", 80) for OnionAddr,
+    444 => Onion("onion") for OnionAddr,
     // Websockets
-    477 => WS("ws", 0) for WSAddr,
+    477 => WS("ws") for WSAddr,
     // Websockets secure
-    478 => WSS("wss", 0) for WSSAddr,
+    478 => WSS("wss") for WSSAddr,
     // libp2p webrtc protocols
-    275 => Libp2pWebrtcStar("libp2p-webrtc-star", 0) for Libp2pWebrtcStarAddr,
-    276 => Libp2pWebrtcDirect("libp2p-webrtc-direct", 0) for Libp2pWebrtcDirectAddr
+    275 => Libp2pWebrtcStar("libp2p-webrtc-star") for Libp2pWebrtcStarAddr,
+    276 => Libp2pWebrtcDirect("libp2p-webrtc-direct") for Libp2pWebrtcDirectAddr
 );
 
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,33 +1,502 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 use std::convert::From;
+use std::fmt;
+use std::hash;
+use std::io;
 use std::io::Cursor;
+use std::io::Read;
+
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use cid::Cid;
-use integer_encoding::VarIntWriter;
+use cid;
+use integer_encoding::{VarInt, VarIntReader, VarIntWriter};
 
 use {Result, Error};
+
 
 ///! # Protocol
 ///!
 ///! A type to describe the possible protocol used in a
 ///! Multiaddr.
 
-macro_rules! build_protocol_enum {
-    {$( $val:expr => $var:ident ( $alph:expr, $size:expr ) ),*} => {
+
+/// Single multiaddress segment with its attached data
+pub trait AddressSegment : fmt::Display + ToString {
+    fn protocol(&self) -> Protocol;
+
+    /// Read address segment data from stream
+    ///
+    /// If the address segment does expect any additional data, then
+    /// no data will be read and an empty struct will be created.
+    fn from_stream(stream: &mut io::Read) -> Result<Self> where Self: Sized;
+
+    /// Generate the canonical binary representation of the contents of this
+    /// address segment
+    ///
+    /// In order to obtain a human-readable string representation use
+    /// `ToString.to_string` instead.
+    fn to_bytes(&self) -> Vec<u8>;
+}
+
+impl<T> From<T> for Protocol where T: AddressSegment {
+    fn from(addr: T) -> Protocol {
+        addr.protocol()
+    }
+}
+
+
+
+/// A trait for reading any kind of address segment from a byte stream
+pub trait AddressSegmentReaderExt<T: AddressSegment> {
+    fn read_addr(&mut self) -> io::Result<T>;
+}
+impl<T: AddressSegment, R: io::Read> AddressSegmentReaderExt<T> for R {
+    fn read_addr(&mut self) -> io::Result<T> {
+        T::from_stream(self).map_err(|err: Error| {
+            io::Error::new(io::ErrorKind::InvalidData, err)
+        })
+    }
+}
+
+
+/// A trait for writing any kind of address segment to a byte stream
+pub trait AddressSegmentWriterExt<T: AddressSegment> {
+    fn write_addr(&mut self, addr: &T) -> io::Result<()>;
+}
+impl<T: AddressSegment, W: io::Write> AddressSegmentWriterExt<T> for W {
+    fn write_addr(&mut self, addr: &T) -> io::Result<()> {
+        self.write_all(addr.to_bytes().as_slice())
+    }
+}
+
+
+macro_rules! derive_for_wrapping_addr {
+    ( $name:ident ) => {};
+    ( $name:ident , $( $rest:tt )+ ) => {
+        derive_for_wrapping_addr!($name : $($rest)*);
+    };
+
+    ( $name:ident : Display $( $rest:tt )* ) => {
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        derive_for_wrapping_addr!($name $($rest)*);
+    };
+
+    ( $name:ident : FromStr $( $rest:tt )* ) => {
+        impl FromStr for $name {
+            type Err = Error;
+
+            fn from_str(s: &str) -> Result<Self> {
+                Ok($name(FromStr::from_str(s)?))
+            }
+        }
+
+        derive_for_wrapping_addr!($name $($rest)*);
+    };
+
+    ( $name:ident : From < $type:path > $( $rest:tt )* ) => {
+        impl From < $type > for $name {
+            fn from(addr: $type ) -> Self {
+                $name (addr)
+            }
+        }
+
+        derive_for_wrapping_addr!($name $($rest)*);
+    };
+}
+
+
+macro_rules! derive_for_empty_addr {
+    ( $name:ident ) => {};
+    ( $name:ident , $( $rest:tt )+ ) => {
+        derive_for_empty_addr!($name : $($rest)*);
+    };
+
+    ( $name:ident : Display $( $rest:tt )* ) => {
+        impl fmt::Display for $name {
+            fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+                Ok(())
+            }
+        }
+
+        derive_for_empty_addr!($name $($rest)*);
+    };
+
+    ( $name:ident : FromStr $( $rest:tt )* ) => {
+        impl FromStr for $name {
+            type Err = Error;
+
+            fn from_str(_: &str) -> Result<Self> {
+                Ok( $name {} )
+            }
+        }
+
+        derive_for_empty_addr!($name $($rest)*);
+    };
+
+    ( $name:ident : Addr < $proto:ident > $( $rest:tt )* ) => {
+        impl AddressSegment for $name {
+            fn protocol(&self) -> Protocol {
+                Protocol::$proto
+            }
+
+            fn from_stream(_: &mut io::Read) -> Result<Self> {
+                Ok($name {})
+            }
+
+            fn to_bytes(&self) -> Vec<u8> {
+                Vec::new()
+            }
+        }
+
+        derive_for_empty_addr!($name $($rest)*);
+    };
+}
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct IP4Addr(pub Ipv4Addr);
+
+derive_for_wrapping_addr!(IP4Addr: Display, FromStr, From<Ipv4Addr>);
+impl AddressSegment for IP4Addr {
+    fn protocol(&self) -> Protocol {
+        Protocol::IP4
+    }
+
+    fn from_stream(stream: &mut io::Read) -> Result<Self> {
+        let mut buf = [0u8; 4];
+        stream.read_exact(&mut buf)?;
+
+        Ok(IP4Addr(Ipv4Addr::new(buf[0], buf[1], buf[2], buf[3])))
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(4);
+        res.extend(self.0.octets().iter().cloned());
+        res
+    }
+}
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct TCPAddr(pub u16);
+
+derive_for_wrapping_addr!(TCPAddr: Display, FromStr, From<u16>);
+impl AddressSegment for TCPAddr {
+    fn protocol(&self) -> Protocol {
+        Protocol::TCP
+    }
+
+    fn from_stream(stream: &mut io::Read) -> Result<Self> {
+        Ok(TCPAddr(stream.read_u16::<BigEndian>()?))
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(2);
+        res.write_u16::<BigEndian>(self.0).unwrap();
+        res
+    }
+}
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct UDPAddr(pub u16);
+
+derive_for_wrapping_addr!(UDPAddr: Display, FromStr, From<u16>);
+impl AddressSegment for UDPAddr {
+    fn protocol(&self) -> Protocol {
+        Protocol::UDP
+    }
+
+    fn from_stream(stream: &mut io::Read) -> Result<Self> {
+        Ok(UDPAddr(stream.read_u16::<BigEndian>()?))
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(2);
+        res.write_u16::<BigEndian>(self.0).unwrap();
+        res
+    }
+}
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct DCCPAddr(pub u16);
+
+derive_for_wrapping_addr!(DCCPAddr: Display, FromStr, From<u16>);
+impl AddressSegment for DCCPAddr {
+    fn protocol(&self) -> Protocol {
+        Protocol::DCCP
+    }
+
+    fn from_stream(stream: &mut io::Read) -> Result<Self> {
+        Ok(DCCPAddr(stream.read_u16::<BigEndian>()?))
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(2);
+        res.write_u16::<BigEndian>(self.0).unwrap();
+        res
+    }
+}
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct IP6Addr(pub Ipv6Addr);
+
+derive_for_wrapping_addr!(IP6Addr: Display, FromStr, From<Ipv6Addr>);
+impl AddressSegment for IP6Addr {
+    fn protocol(&self) -> Protocol {
+        Protocol::IP6
+    }
+
+    fn from_stream(stream: &mut io::Read) -> Result<Self> {
+        Ok(IP6Addr(
+            Ipv6Addr::new(
+                stream.read_u16::<BigEndian>()?,
+                stream.read_u16::<BigEndian>()?,
+                stream.read_u16::<BigEndian>()?,
+                stream.read_u16::<BigEndian>()?,
+                stream.read_u16::<BigEndian>()?,
+                stream.read_u16::<BigEndian>()?,
+                stream.read_u16::<BigEndian>()?,
+                stream.read_u16::<BigEndian>()?
+            )
+        ))
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(16);
+        for segment in &self.0.segments() {
+            res.write_u16::<BigEndian>(*segment).unwrap();
+        }
+        res
+    }
+}
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct SCTPAddr(pub u16);
+
+derive_for_wrapping_addr!(SCTPAddr: Display, FromStr, From<u16>);
+impl AddressSegment for SCTPAddr {
+    fn protocol(&self) -> Protocol {
+        Protocol::SCTP
+    }
+
+    fn from_stream(stream: &mut io::Read) -> Result<Self> {
+        Ok(SCTPAddr(stream.read_u16::<BigEndian>()?))
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(2);
+        res.write_u16::<BigEndian>(self.0).unwrap();
+        res
+    }
+}
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct UDTAddr;
+
+derive_for_empty_addr!(UDTAddr: Display, FromStr, Addr<UDT>);
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct UTPAddr;
+
+derive_for_empty_addr!(UTPAddr: Display, FromStr, Addr<UTP>);
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct IPFSAddr(pub cid::Cid);
+
+derive_for_wrapping_addr!(IPFSAddr: Display, From<cid::Cid>);
+impl IPFSAddr {
+    fn _read_cid_polyfill(stream: &mut io::Read) -> Result<cid::Cid> {
+        // Read minimal CID length at start to check for CIDv0
+        let mut buf = [0u8; 34];
+        stream.read_exact(&mut buf)?;
+
+        if cid::Version::is_v0_binary(&buf) {
+            Ok(cid::Cid::from(&buf as &[u8])?)
+        } else {
+            // Do normal CID parsing using the already read data
+            let mut stream = Cursor::new(&buf as &[u8]).chain(stream);
+
+            // Read and parse CID header
+            let raw_version = stream.read_varint()?;
+            let raw_codec = stream.read_varint()?;
+            let _: u64 = stream.read_varint()?;
+
+            let version = cid::Version::from(raw_version)?;
+            let codec = cid::Codec::from(raw_codec)?;
+
+            let mh_len = stream.read_varint()?;
+
+            // Read CID hash data
+            // (Unsafe because data in `Vec` contains uninitialized memory
+            //  until we overwrite it with data read from `stream`.)
+            let mut hash = Vec::with_capacity(mh_len);
+            unsafe { hash.set_len(mh_len) };
+            stream.read_exact(hash.as_mut())?;
+
+            Ok(cid::Cid::new(codec, version, hash.as_slice()))
+        }
+    }
+}
+
+impl AddressSegment for IPFSAddr {
+    fn protocol(&self) -> Protocol {
+        Protocol::IPFS
+    }
+
+    fn from_stream(stream: &mut io::Read) -> Result<Self> {
+        //FIXME: `cid::Prefix` creates its own `Cursor` instead of
+        //       overloading `io::Read`
+
+        // Read CID hash from stream
+        let cid = Self::_read_cid_polyfill(stream).map_err(|err| {
+            println!("CID Parsing failed!");
+            err
+        })?;
+
+        Ok(IPFSAddr(cid))
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let bytes = self.0.to_bytes();
+
+        let mut res = Vec::with_capacity(bytes.len().required_space() + bytes.len());
+        res.write_varint(bytes.len()).unwrap();
+        res.extend(bytes);
+        res
+    }
+}
+
+impl FromStr for IPFSAddr {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        //FIXME: `cid::Cid` does not implement `FromStr`
+        Ok(IPFSAddr(cid::Cid::from(s)?))
+    }
+}
+
+impl hash::Hash for IPFSAddr {
+    fn hash<H>(&self, state: &mut H) where H: hash::Hasher {
+        //FIXME: `cid::Cid` does not derive `Hash`
+        state.write_usize(self.0.version as usize);
+        state.write_usize(self.0.codec as usize);
+        hash::Hash::hash(&self.0.hash, state);
+    }
+}
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct HTTPAddr;
+
+derive_for_empty_addr!(HTTPAddr: Display, FromStr, Addr<HTTP>);
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct HTTPSAddr;
+
+derive_for_empty_addr!(HTTPSAddr: Display, FromStr, Addr<HTTPS>);
+
+
+
+//TODO: Properly parse and format union addresses
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct OnionAddr(pub Box<[u8; 10]>);
+
+derive_for_empty_addr!(OnionAddr: Display);
+impl AddressSegment for OnionAddr {
+    fn protocol(&self) -> Protocol {
+        Protocol::Onion
+    }
+
+    fn from_stream(_: &mut io::Read) -> Result<Self> {
+        Err(Error::ParsingError)
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        Vec::new()
+    }
+}
+
+impl FromStr for OnionAddr {
+    type Err = Error;
+
+    fn from_str(_: &str) -> Result<Self> {
+        Err(Error::ParsingError)
+    }
+}
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct WSAddr;
+
+derive_for_empty_addr!(WSAddr: Display, FromStr, Addr<WS>);
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct WSSAddr;
+
+derive_for_empty_addr!(WSSAddr: Display, FromStr, Addr<WSS>);
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct Libp2pWebrtcStarAddr;
+
+derive_for_empty_addr!(Libp2pWebrtcStarAddr: Display, FromStr, Addr<Libp2pWebrtcStar>);
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct Libp2pWebrtcDirectAddr;
+
+derive_for_empty_addr!(Libp2pWebrtcDirectAddr: Display, FromStr, Addr<Libp2pWebrtcDirect>);
+
+
+
+macro_rules! build_enums {
+    { $( $val:expr => $var:ident ( $alph:expr, $size:expr ) for $addr_type:ident ),* } => {
         /// Protocol is the list of all possible protocols.
+        //XXX: #[non_exhaustive] is not stable yet
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
         pub enum Protocol {
             $( $var = $val, )*
+            
+            /// We want to be able to add new multiaddrs types in the future
+            #[doc(hidden)]
+            __Nonexhaustive
         }
-
-        use Protocol::*;
 
         impl From<Protocol> for u64 {
             /// Convert to the matching integer code
             fn from(proto: Protocol) -> u64 {
                 match proto {
-                    $( $var => $val, )*
+                    $( Protocol::$var => $val, )*
+                    _ => unreachable!()
                 }
             }
         }
@@ -35,7 +504,8 @@ macro_rules! build_protocol_enum {
         impl ToString for Protocol {
             fn to_string(&self) -> String {
                 match *self {
-                    $( $var => $alph.to_string(), )*
+                    $( Protocol::$var => $alph.to_string(), )*
+                    _ => unreachable!()
                 }
             }
         }
@@ -45,8 +515,8 @@ macro_rules! build_protocol_enum {
 
             fn from_str(raw: &str) -> Result<Self> {
                 match raw {
-                    $( $alph => Ok($var), )*
-                    _ => Err(Error::UnkownProtocolString),
+                    $( $alph => Ok(Protocol::$var), )*
+                    _ => Err(Error::UnkownProtocolString)
                 }
             }
         }
@@ -65,8 +535,8 @@ macro_rules! build_protocol_enum {
             /// ```
             pub fn from(raw: u64) -> Result<Protocol> {
                 match raw {
-                    $( $val => Ok($var), )*
-                    _ => Err(Error::UnkownProtocol),
+                    $( $val => Ok(Protocol::$var), )*
+                    _ => Err(Error::UnkownProtocol)
                 }
             }
 
@@ -82,46 +552,109 @@ macro_rules! build_protocol_enum {
             ///
             pub fn size(&self) -> isize {
                 match *self {
-                    $( $var => $size, )*
+                    $( Protocol::$var => $size, )*
+                    _ => unreachable!()
+                }
+            }
+        }
+
+
+        /// Enumeration of all known address segment types
+        //XXX: #[non_exhaustive] is not stable yet
+        #[derive(Debug, PartialEq, Eq, Clone, Hash)]
+        pub enum Addr {
+            $( $var( $addr_type ), )*
+            
+            /// We want to be able to add new multiaddrs types in the future
+            #[doc(hidden)]
+            __Nonexhaustive
+        }
+
+        impl Addr {
+            /// Create address segment for the given protocol number and with
+            /// data from `stream`
+            pub fn from_protocol_stream(protocol: Protocol, stream: &mut io::Read) -> Result<Self> {
+                Ok(match protocol {
+                    $( Protocol::$var => Addr::$var($addr_type::from_stream(stream)?), )*
+                    _ => unreachable!()
+                })
+            }
+
+            pub fn from_protocol_str(protocol: Protocol, s: &str) -> Result<Self> {
+                Ok(match protocol {
+                    $( Protocol::$var => Addr::$var($addr_type::from_str(s)?), )*
+                    _ => unreachable!()
+                })
+            }
+        }
+
+        impl fmt::Display for Addr {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match self {
+                    $( &Addr::$var(ref addr) => fmt::Display::fmt(addr, f), )*
+                    _ => unreachable!()
+                }
+            }
+        }
+
+        impl AddressSegment for Addr {
+            fn protocol(&self) -> Protocol {
+                match self {
+                    $( &Addr::$var(ref addr) => addr.protocol(), )*
+                    _ => unreachable!()
+                }
+            }
+
+            fn from_stream(mut stream: &mut io::Read) -> Result<Self> {
+                let protocol = Protocol::from(stream.read_varint()?)?;
+                Addr::from_protocol_stream(protocol, stream)
+            }
+
+            fn to_bytes(&self) -> Vec<u8> {
+                match self {
+                    $( &Addr::$var(ref addr) => addr.to_bytes(), )*
+                    _ => unreachable!()
                 }
             }
         }
     }
 }
 
-build_protocol_enum!(
+
+build_enums!(
     // [IP4](https://en.wikipedia.org/wiki/IPv4)
-    4 => IP4("ip4", 32),
+    4 => IP4("ip4", 32) for IP4Addr,
     // [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol)
-    6 => TCP("tcp", 16),
+    6 => TCP("tcp", 16) for TCPAddr,
     // [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol)
-    17 => UDP("udp", 16),
+    17 => UDP("udp", 16) for UDPAddr,
     // [DCCP](https://en.wikipedia.org/wiki/Datagram_Congestion_Control_Protocol)
-    33 => DCCP("dccp", 16),
+    33 => DCCP("dccp", 16) for DCCPAddr,
     // [IP6](https://en.wikipedia.org/wiki/IPv6)
-    41 => IP6("ip6", 128),
+    41 => IP6("ip6", 128) for IP6Addr,
     // [SCTP](https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol)
-    132 => SCTP("sctp", 16),
+    132 => SCTP("sctp", 16) for SCTPAddr,
     // [UDT](https://en.wikipedia.org/wiki/UDP-based_Data_Transfer_Protocol)
-    301 => UDT("udt", 0),
+    301 => UDT("udt", 0) for UDTAddr,
     // [UTP](https://en.wikipedia.org/wiki/Micro_Transport_Protocol)
-    302 => UTP("utp", 0),
+    302 => UTP("utp", 0) for UTPAddr,
     // [IPFS](https://github.com/ipfs/specs/tree/master/protocol#341-merkledag-paths)
-    421 => IPFS("ipfs", -1),
+    421 => IPFS("ipfs", -1) for IPFSAddr,
     // [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)
-    480 => HTTP("http", 0),
+    480 => HTTP("http", 0) for HTTPAddr,
     // [HTTPS](https://en.wikipedia.org/wiki/HTTPS)
-    443 => HTTPS("https", 0),
+    443 => HTTPS("https", 0) for HTTPSAddr,
     // Onion
-    444 => ONION("onion", 80),
+    444 => Onion("onion", 80) for OnionAddr,
     // Websockets
-    477 => WS("ws", 0),
+    477 => WS("ws", 0) for WSAddr,
     // Websockets secure
-    478 => WSS("wss", 0),
+    478 => WSS("wss", 0) for WSSAddr,
     // libp2p webrtc protocols
-    275 => Libp2pWebrtcStar("libp2p-webrtc-star", 0),
-    276 => Libp2pWebrtcDirect("libp2p-webrtc-direct", 0)
+    275 => Libp2pWebrtcStar("libp2p-webrtc-star", 0) for Libp2pWebrtcStarAddr,
+    276 => Libp2pWebrtcDirect("libp2p-webrtc-direct", 0) for Libp2pWebrtcDirectAddr
 );
+
 
 
 impl Protocol {
@@ -136,56 +669,9 @@ impl Protocol {
     /// assert_eq!(proto.string_to_bytes("127.0.0.1").unwrap(), [127, 0, 0, 1]);
     /// ```
     ///
+    #[deprecated(note = "Use `Addr::from_protocol_str` and `.to_bytes()` instead")]
     pub fn string_to_bytes(&self, a: &str) -> Result<Vec<u8>> {
-        use Protocol::*;
-
-        match *self {
-            IP4 => {
-                let addr = Ipv4Addr::from_str(a)?;
-                let mut res = Vec::new();
-                res.extend(addr.octets().iter().cloned());
-
-                Ok(res)
-            }
-            IP6 => {
-                let addr = Ipv6Addr::from_str(a)?;
-                let mut res = Vec::new();
-
-                for segment in &addr.segments() {
-                    res.write_u16::<BigEndian>(*segment)?;
-                }
-
-                Ok(res)
-            }
-            TCP | UDP | DCCP | SCTP => {
-                let parsed: u16 = a.parse()?;
-                let mut res = Vec::new();
-                res.write_u16::<BigEndian>(parsed)?;
-
-                Ok(res)
-            }
-            IPFS => {
-                let bytes = Cid::from(a)?.to_bytes();
-                let mut res = vec![];
-                res.write_varint(bytes.len())?;
-                res.extend(bytes);
-
-                Ok(res)
-            }
-            ONION => Ok(Vec::new()),
-            UTP |
-            UDT |
-            HTTP |
-            HTTPS |
-            WS |
-            WSS |
-            Libp2pWebrtcStar |
-            Libp2pWebrtcDirect => {
-                // These all have length 0 so just return an empty vector
-                // for consistency
-                Ok(Vec::new())
-            }
-        }
+        Ok(Addr::from_protocol_str(*self, a)?.to_bytes())
     }
 
     /// Convert an array slice to the string representation.
@@ -205,49 +691,15 @@ impl Protocol {
     /// If there is no address representation for the protocol, like for `https`
     /// then `None` is returned.
     ///
+    #[deprecated(note = "Use `Addr::from_protocol_stream` and `.to_string()` instead")]
     pub fn bytes_to_string(&self, b: &[u8]) -> Result<Option<String>> {
-        use Protocol::*;
+        let mut cursor = Cursor::new(b);
 
-        match *self {
-            IP4 => Ok(Some(Ipv4Addr::new(b[0], b[1], b[2], b[3]).to_string())),
-            IP6 => {
-                let mut rdr = Cursor::new(b);
-                let mut seg = vec![];
-
-                for _ in 0..8 {
-                    seg.push(rdr.read_u16::<BigEndian>()?);
-                }
-
-                Ok(Some(Ipv6Addr::new(seg[0],
-                                      seg[1],
-                                      seg[2],
-                                      seg[3],
-                                      seg[4],
-                                      seg[5],
-                                      seg[6],
-                                      seg[7])
-                    .to_string()))
-            }
-            TCP | UDP | DCCP | SCTP => {
-                let mut rdr = Cursor::new(b);
-                let num = rdr.read_u16::<BigEndian>()?;
-
-                Ok(Some(num.to_string()))
-            }
-            IPFS => {
-                let c = Cid::from(b)?;
-
-                Ok(Some(c.to_string()))
-            }
-            ONION => Ok(None),
-            UTP |
-            UDT |
-            HTTP |
-            HTTPS |
-            WS |
-            WSS |
-            Libp2pWebrtcStar |
-            Libp2pWebrtcDirect => Ok(None),
+        let string = Addr::from_protocol_stream(*self, &mut cursor)?.to_string();
+        if string.len() < 1 {
+            Ok(None)
+        } else {
+            Ok(Some(string))
         }
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -14,7 +14,7 @@ use {Result, Error};
 ///! Multiaddr.
 
 macro_rules! build_protocol_enum {
-    {$( $val:expr => $var:ident: $alph:expr, $size:expr, )*} => {
+    {$( $val:expr => $var:ident ( $alph:expr, $size:expr ) ),*} => {
         /// Protocol is the list of all possible protocols.
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
         pub enum Protocol {
@@ -91,36 +91,36 @@ macro_rules! build_protocol_enum {
 
 build_protocol_enum!(
     // [IP4](https://en.wikipedia.org/wiki/IPv4)
-    4 => IP4: "ip4", 32,
+    4 => IP4("ip4", 32),
     // [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol)
-    6 => TCP: "tcp", 16,
+    6 => TCP("tcp", 16),
     // [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol)
-    17 => UDP: "udp", 16,
+    17 => UDP("udp", 16),
     // [DCCP](https://en.wikipedia.org/wiki/Datagram_Congestion_Control_Protocol)
-    33 => DCCP: "dccp", 16,
+    33 => DCCP("dccp", 16),
     // [IP6](https://en.wikipedia.org/wiki/IPv6)
-    41 => IP6: "ip6", 128,
+    41 => IP6("ip6", 128),
     // [SCTP](https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol)
-    132 => SCTP: "sctp", 16,
+    132 => SCTP("sctp", 16),
     // [UDT](https://en.wikipedia.org/wiki/UDP-based_Data_Transfer_Protocol)
-    301 => UDT: "udt", 0,
+    301 => UDT("udt", 0),
     // [UTP](https://en.wikipedia.org/wiki/Micro_Transport_Protocol)
-    302 => UTP: "utp", 0,
+    302 => UTP("utp", 0),
     // [IPFS](https://github.com/ipfs/specs/tree/master/protocol#341-merkledag-paths)
-    421 => IPFS: "ipfs", -1,
+    421 => IPFS("ipfs", -1),
     // [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)
-    480 => HTTP: "http", 0,
+    480 => HTTP("http", 0),
     // [HTTPS](https://en.wikipedia.org/wiki/HTTPS)
-    443 => HTTPS: "https", 0,
+    443 => HTTPS("https", 0),
     // Onion
-    444 => ONION: "onion", 80,
+    444 => ONION("onion", 80),
     // Websockets
-    477 => WS: "ws", 0,
+    477 => WS("ws", 0),
     // Websockets secure
-    478 => WSS: "wss", 0,
+    478 => WSS("wss", 0),
     // libp2p webrtc protocols
-    275 => Libp2pWebrtcStar: "libp2p-webrtc-star", 0,
-    276 => Libp2pWebrtcDirect: "libp2p-webrtc-direct", 0,
+    275 => Libp2pWebrtcStar("libp2p-webrtc-star", 0),
+    276 => Libp2pWebrtcDirect("libp2p-webrtc-direct", 0)
 );
 
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -72,10 +72,10 @@ impl<T: AddressSegment, W: io::Write> AddressSegmentWriterExt<T> for W {
 }
 
 
-macro_rules! derive_for_wrapping_addr {
+macro_rules! derive_for_wrapping_segment {
     ( $name:ident ) => {};
     ( $name:ident , $( $rest:tt )+ ) => {
-        derive_for_wrapping_addr!($name : $($rest)*);
+        derive_for_wrapping_segment!($name : $($rest)*);
     };
 
     ( $name:ident : Display $( $rest:tt )* ) => {
@@ -85,7 +85,7 @@ macro_rules! derive_for_wrapping_addr {
             }
         }
 
-        derive_for_wrapping_addr!($name $($rest)*);
+        derive_for_wrapping_segment!($name $($rest)*);
     };
 
     ( $name:ident : FromStr $( $rest:tt )* ) => {
@@ -97,7 +97,7 @@ macro_rules! derive_for_wrapping_addr {
             }
         }
 
-        derive_for_wrapping_addr!($name $($rest)*);
+        derive_for_wrapping_segment!($name $($rest)*);
     };
 
     ( $name:ident : From < $type:path > $( $rest:tt )* ) => {
@@ -107,15 +107,15 @@ macro_rules! derive_for_wrapping_addr {
             }
         }
 
-        derive_for_wrapping_addr!($name $($rest)*);
+        derive_for_wrapping_segment!($name $($rest)*);
     };
 }
 
 
-macro_rules! derive_for_empty_addr {
+macro_rules! derive_for_empty_segment {
     ( $name:ident ) => {};
     ( $name:ident , $( $rest:tt )+ ) => {
-        derive_for_empty_addr!($name : $($rest)*);
+        derive_for_empty_segment!($name : $($rest)*);
     };
 
     ( $name:ident : Display $( $rest:tt )* ) => {
@@ -125,7 +125,7 @@ macro_rules! derive_for_empty_addr {
             }
         }
 
-        derive_for_empty_addr!($name $($rest)*);
+        derive_for_empty_segment!($name $($rest)*);
     };
 
     ( $name:ident : FromStr $( $rest:tt )* ) => {
@@ -137,10 +137,10 @@ macro_rules! derive_for_empty_addr {
             }
         }
 
-        derive_for_empty_addr!($name $($rest)*);
+        derive_for_empty_segment!($name $($rest)*);
     };
 
-    ( $name:ident : Addr < $proto:ident > $( $rest:tt )* ) => {
+    ( $name:ident : AddressSegment < $proto:ident > $( $rest:tt )* ) => {
         impl AddressSegment for $name {
             fn protocol(&self) -> Protocol {
                 Protocol::$proto
@@ -155,17 +155,17 @@ macro_rules! derive_for_empty_addr {
             }
         }
 
-        derive_for_empty_addr!($name $($rest)*);
+        derive_for_empty_segment!($name $($rest)*);
     };
 }
 
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct IP4Addr(pub Ipv4Addr);
+pub struct IP4Segment(pub Ipv4Addr);
 
-derive_for_wrapping_addr!(IP4Addr: Display, FromStr, From<Ipv4Addr>);
-impl AddressSegment for IP4Addr {
+derive_for_wrapping_segment!(IP4Segment: Display, FromStr, From<Ipv4Addr>);
+impl AddressSegment for IP4Segment {
     const STREAM_LENGTH: usize = 4;
 
     fn protocol(&self) -> Protocol {
@@ -176,7 +176,7 @@ impl AddressSegment for IP4Addr {
         let mut buf = [0u8; 4];
         stream.read_exact(&mut buf)?;
 
-        Ok(IP4Addr(Ipv4Addr::new(buf[0], buf[1], buf[2], buf[3])))
+        Ok(IP4Segment(Ipv4Addr::new(buf[0], buf[1], buf[2], buf[3])))
     }
 
     fn to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
@@ -187,10 +187,10 @@ impl AddressSegment for IP4Addr {
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct TCPAddr(pub u16);
+pub struct TCPSegment(pub u16);
 
-derive_for_wrapping_addr!(TCPAddr: Display, FromStr, From<u16>);
-impl AddressSegment for TCPAddr {
+derive_for_wrapping_segment!(TCPSegment: Display, FromStr, From<u16>);
+impl AddressSegment for TCPSegment {
     const STREAM_LENGTH: usize = 2;
 
     fn protocol(&self) -> Protocol {
@@ -198,7 +198,7 @@ impl AddressSegment for TCPAddr {
     }
 
     fn from_stream(stream: &mut io::Read) -> Result<Self> {
-        Ok(TCPAddr(stream.read_u16::<BigEndian>()?))
+        Ok(TCPSegment(stream.read_u16::<BigEndian>()?))
     }
 
     fn to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
@@ -209,10 +209,10 @@ impl AddressSegment for TCPAddr {
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct UDPAddr(pub u16);
+pub struct UDPSegment(pub u16);
 
-derive_for_wrapping_addr!(UDPAddr: Display, FromStr, From<u16>);
-impl AddressSegment for UDPAddr {
+derive_for_wrapping_segment!(UDPSegment: Display, FromStr, From<u16>);
+impl AddressSegment for UDPSegment {
     const STREAM_LENGTH: usize = 2;
 
     fn protocol(&self) -> Protocol {
@@ -220,7 +220,7 @@ impl AddressSegment for UDPAddr {
     }
 
     fn from_stream(stream: &mut io::Read) -> Result<Self> {
-        Ok(UDPAddr(stream.read_u16::<BigEndian>()?))
+        Ok(UDPSegment(stream.read_u16::<BigEndian>()?))
     }
 
     fn to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
@@ -231,10 +231,10 @@ impl AddressSegment for UDPAddr {
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct DCCPAddr(pub u16);
+pub struct DCCPSegment(pub u16);
 
-derive_for_wrapping_addr!(DCCPAddr: Display, FromStr, From<u16>);
-impl AddressSegment for DCCPAddr {
+derive_for_wrapping_segment!(DCCPSegment: Display, FromStr, From<u16>);
+impl AddressSegment for DCCPSegment {
     const STREAM_LENGTH: usize = 2;
 
     fn protocol(&self) -> Protocol {
@@ -242,7 +242,7 @@ impl AddressSegment for DCCPAddr {
     }
 
     fn from_stream(stream: &mut io::Read) -> Result<Self> {
-        Ok(DCCPAddr(stream.read_u16::<BigEndian>()?))
+        Ok(DCCPSegment(stream.read_u16::<BigEndian>()?))
     }
 
     fn to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
@@ -253,10 +253,10 @@ impl AddressSegment for DCCPAddr {
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct IP6Addr(pub Ipv6Addr);
+pub struct IP6Segment(pub Ipv6Addr);
 
-derive_for_wrapping_addr!(IP6Addr: Display, FromStr, From<Ipv6Addr>);
-impl AddressSegment for IP6Addr {
+derive_for_wrapping_segment!(IP6Segment: Display, FromStr, From<Ipv6Addr>);
+impl AddressSegment for IP6Segment {
     const STREAM_LENGTH: usize = 16;
 
     fn protocol(&self) -> Protocol {
@@ -264,7 +264,7 @@ impl AddressSegment for IP6Addr {
     }
 
     fn from_stream(stream: &mut io::Read) -> Result<Self> {
-        Ok(IP6Addr(
+        Ok(IP6Segment(
             Ipv6Addr::new(
                 stream.read_u16::<BigEndian>()?,
                 stream.read_u16::<BigEndian>()?,
@@ -289,10 +289,10 @@ impl AddressSegment for IP6Addr {
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct SCTPAddr(pub u16);
+pub struct SCTPSegment(pub u16);
 
-derive_for_wrapping_addr!(SCTPAddr: Display, FromStr, From<u16>);
-impl AddressSegment for SCTPAddr {
+derive_for_wrapping_segment!(SCTPSegment: Display, FromStr, From<u16>);
+impl AddressSegment for SCTPSegment {
     const STREAM_LENGTH: usize = 2;
 
     fn protocol(&self) -> Protocol {
@@ -300,7 +300,7 @@ impl AddressSegment for SCTPAddr {
     }
 
     fn from_stream(stream: &mut io::Read) -> Result<Self> {
-        Ok(SCTPAddr(stream.read_u16::<BigEndian>()?))
+        Ok(SCTPSegment(stream.read_u16::<BigEndian>()?))
     }
 
     fn to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
@@ -311,24 +311,24 @@ impl AddressSegment for SCTPAddr {
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct UDTAddr;
+pub struct UDTSegment;
 
-derive_for_empty_addr!(UDTAddr: Display, FromStr, Addr<UDT>);
+derive_for_empty_segment!(UDTSegment: Display, FromStr, AddressSegment<UDT>);
 
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct UTPAddr;
+pub struct UTPSegment;
 
-derive_for_empty_addr!(UTPAddr: Display, FromStr, Addr<UTP>);
+derive_for_empty_segment!(UTPSegment: Display, FromStr, AddressSegment<UTP>);
 
 
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct IPFSAddr(pub cid::Cid);
+pub struct IPFSSegment(pub cid::Cid);
 
-derive_for_wrapping_addr!(IPFSAddr: Display, From<cid::Cid>);
-impl IPFSAddr {
+derive_for_wrapping_segment!(IPFSSegment: Display, From<cid::Cid>);
+impl IPFSSegment {
     fn _read_cid_polyfill(stream: &mut io::Read) -> Result<cid::Cid> {
         // Read minimal CID length at start to check for CIDv0
         let mut buf = [0u8; 34];
@@ -362,7 +362,7 @@ impl IPFSAddr {
     }
 }
 
-impl AddressSegment for IPFSAddr {
+impl AddressSegment for IPFSSegment {
     const STREAM_LENGTH: usize = 34;
 
     fn protocol(&self) -> Protocol {
@@ -379,7 +379,7 @@ impl AddressSegment for IPFSAddr {
             err
         })?;
 
-        Ok(IPFSAddr(cid))
+        Ok(IPFSSegment(cid))
     }
 
     fn to_stream(&self, mut stream: &mut io::Write) -> io::Result<()> {
@@ -392,16 +392,16 @@ impl AddressSegment for IPFSAddr {
     }
 }
 
-impl FromStr for IPFSAddr {
+impl FromStr for IPFSSegment {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
         //FIXME: `cid::Cid` does not implement `FromStr`
-        Ok(IPFSAddr(cid::Cid::from(s)?))
+        Ok(IPFSSegment(cid::Cid::from(s)?))
     }
 }
 
-impl hash::Hash for IPFSAddr {
+impl hash::Hash for IPFSSegment {
     fn hash<H>(&self, state: &mut H) where H: hash::Hasher {
         //FIXME: `cid::Cid` does not derive `Hash`
         state.write_usize(self.0.version as usize);
@@ -413,25 +413,25 @@ impl hash::Hash for IPFSAddr {
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct HTTPAddr;
+pub struct HTTPSegment;
 
-derive_for_empty_addr!(HTTPAddr: Display, FromStr, Addr<HTTP>);
+derive_for_empty_segment!(HTTPSegment: Display, FromStr, AddressSegment<HTTP>);
 
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct HTTPSAddr;
+pub struct HTTPSSegment;
 
-derive_for_empty_addr!(HTTPSAddr: Display, FromStr, Addr<HTTPS>);
+derive_for_empty_segment!(HTTPSSegment: Display, FromStr, AddressSegment<HTTPS>);
 
 
 
 //TODO: Properly parse and format union addresses
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct OnionAddr(pub Box<[u8; 10]>);
+pub struct OnionSegment(pub Box<[u8; 10]>);
 
-derive_for_empty_addr!(OnionAddr: Display);
-impl AddressSegment for OnionAddr {
+derive_for_empty_segment!(OnionSegment: Display);
+impl AddressSegment for OnionSegment {
     const STREAM_LENGTH: usize = 80;
 
     fn protocol(&self) -> Protocol {
@@ -447,7 +447,7 @@ impl AddressSegment for OnionAddr {
     }
 }
 
-impl FromStr for OnionAddr {
+impl FromStr for OnionSegment {
     type Err = Error;
 
     fn from_str(_: &str) -> Result<Self> {
@@ -458,30 +458,30 @@ impl FromStr for OnionAddr {
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct WSAddr;
+pub struct WSSegment;
 
-derive_for_empty_addr!(WSAddr: Display, FromStr, Addr<WS>);
-
-
-
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct WSSAddr;
-
-derive_for_empty_addr!(WSSAddr: Display, FromStr, Addr<WSS>);
+derive_for_empty_segment!(WSSegment: Display, FromStr, AddressSegment<WS>);
 
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct Libp2pWebrtcStarAddr;
+pub struct WSSSegment;
 
-derive_for_empty_addr!(Libp2pWebrtcStarAddr: Display, FromStr, Addr<Libp2pWebrtcStar>);
+derive_for_empty_segment!(WSSSegment: Display, FromStr, AddressSegment<WSS>);
 
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct Libp2pWebrtcDirectAddr;
+pub struct Libp2pWebrtcStarSegment;
 
-derive_for_empty_addr!(Libp2pWebrtcDirectAddr: Display, FromStr, Addr<Libp2pWebrtcDirect>);
+derive_for_empty_segment!(Libp2pWebrtcStarSegment: Display, FromStr, AddressSegment<Libp2pWebrtcStar>);
+
+
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct Libp2pWebrtcDirectSegment;
+
+derive_for_empty_segment!(Libp2pWebrtcDirectSegment: Display, FromStr, AddressSegment<Libp2pWebrtcDirect>);
 
 
 
@@ -548,7 +548,7 @@ macro_rules! build_enums {
             /// `Protocol` in bits.
             ///
             /// Note the values are only estimates and calling `.to_stream()`
-            /// on a corresponding `Addr` instance may result in a buffer of a
+            /// on a corresponding `Segment` instance may result in a buffer of a
             /// different size. The only noteworthy execption is a returned
             /// value of `0` which guarantees that the given protocol will
             /// never expect a value parameter and will never read or write
@@ -584,7 +584,7 @@ macro_rules! build_enums {
         /// Enumeration of all known address segment types
         //XXX: #[non_exhaustive] is not stable yet
         #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-        pub enum Addr {
+        pub enum Segment {
             $( $var( $addr_type ), )*
             
             /// We want to be able to add new multiaddrs types in the future
@@ -592,49 +592,49 @@ macro_rules! build_enums {
             __Nonexhaustive
         }
 
-        impl Addr {
+        impl Segment {
             /// Create address segment for the given protocol number and with
             /// data from `stream`
             pub fn from_protocol_stream(protocol: Protocol, stream: &mut io::Read) -> Result<Self> {
                 Ok(match protocol {
-                    $( Protocol::$var => Addr::$var($addr_type::from_stream(stream)?), )*
+                    $( Protocol::$var => Segment::$var($addr_type::from_stream(stream)?), )*
                     _ => unreachable!()
                 })
             }
 
             pub fn from_protocol_str(protocol: Protocol, s: &str) -> Result<Self> {
                 Ok(match protocol {
-                    $( Protocol::$var => Addr::$var($addr_type::from_str(s)?), )*
+                    $( Protocol::$var => Segment::$var($addr_type::from_str(s)?), )*
                     _ => unreachable!()
                 })
             }
         }
 
-        impl fmt::Display for Addr {
+        impl fmt::Display for Segment {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 match self {
-                    $( &Addr::$var(ref addr) => fmt::Display::fmt(addr, f), )*
+                    $( &Segment::$var(ref addr) => fmt::Display::fmt(addr, f), )*
                     _ => unreachable!()
                 }
             }
         }
 
-        impl AddressSegment for Addr {
+        impl AddressSegment for Segment {
             fn protocol(&self) -> Protocol {
                 match self {
-                    $( &Addr::$var(ref addr) => addr.protocol(), )*
+                    $( &Segment::$var(ref addr) => addr.protocol(), )*
                     _ => unreachable!()
                 }
             }
 
             fn from_stream(mut stream: &mut io::Read) -> Result<Self> {
                 let protocol = Protocol::from(stream.read_varint()?)?;
-                Addr::from_protocol_stream(protocol, stream)
+                Segment::from_protocol_stream(protocol, stream)
             }
 
             fn to_stream(&self, mut stream: &mut io::Write) -> io::Result<()> {
                 match self {
-                    $( &Addr::$var(ref addr) => {
+                    $( &Segment::$var(ref addr) => {
                         // Write protocol number
                         stream.write_varint(u64::from(addr.protocol()))?;
 
@@ -650,14 +650,14 @@ macro_rules! build_enums {
             }
         }
 
-        impl Addr {
+        impl Segment {
             /// Serialize only the variant's data to bytes
             ///
             /// Will return the result of calling `.to_bytes()` on the inner
             /// address segment instance.
             pub fn data_to_stream(&self, stream: &mut io::Write) -> io::Result<()> {
                 match self {
-                    $( &Addr::$var(ref addr) => addr.to_stream(stream), )*
+                    $( &Segment::$var(ref addr) => addr.to_stream(stream), )*
                     _ => unreachable!()
                 }
             }
@@ -668,36 +668,36 @@ macro_rules! build_enums {
 
 build_enums!(
     // [IP4](https://en.wikipedia.org/wiki/IPv4)
-    4 => IP4("ip4") for IP4Addr,
+    4 => IP4("ip4") for IP4Segment,
     // [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol)
-    6 => TCP("tcp") for TCPAddr,
+    6 => TCP("tcp") for TCPSegment,
     // [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol)
-    17 => UDP("udp") for UDPAddr,
+    17 => UDP("udp") for UDPSegment,
     // [DCCP](https://en.wikipedia.org/wiki/Datagram_Congestion_Control_Protocol)
-    33 => DCCP("dccp") for DCCPAddr,
+    33 => DCCP("dccp") for DCCPSegment,
     // [IP6](https://en.wikipedia.org/wiki/IPv6)
-    41 => IP6("ip6") for IP6Addr,
+    41 => IP6("ip6") for IP6Segment,
     // [SCTP](https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol)
-    132 => SCTP("sctp") for SCTPAddr,
+    132 => SCTP("sctp") for SCTPSegment,
     // [UDT](https://en.wikipedia.org/wiki/UDP-based_Data_Transfer_Protocol)
-    301 => UDT("udt") for UDTAddr,
+    301 => UDT("udt") for UDTSegment,
     // [UTP](https://en.wikipedia.org/wiki/Micro_Transport_Protocol)
-    302 => UTP("utp") for UTPAddr,
+    302 => UTP("utp") for UTPSegment,
     // [IPFS](https://github.com/ipfs/specs/tree/master/protocol#341-merkledag-paths)
-    421 => IPFS("ipfs") for IPFSAddr,
+    421 => IPFS("ipfs") for IPFSSegment,
     // [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)
-    480 => HTTP("http") for HTTPAddr,
+    480 => HTTP("http") for HTTPSegment,
     // [HTTPS](https://en.wikipedia.org/wiki/HTTPS)
-    443 => HTTPS("https") for HTTPSAddr,
+    443 => HTTPS("https") for HTTPSSegment,
     // Onion
-    444 => Onion("onion") for OnionAddr,
+    444 => Onion("onion") for OnionSegment,
     // Websockets
-    477 => WS("ws") for WSAddr,
+    477 => WS("ws") for WSSegment,
     // Websockets secure
-    478 => WSS("wss") for WSSAddr,
+    478 => WSS("wss") for WSSSegment,
     // libp2p webrtc protocols
-    275 => Libp2pWebrtcStar("libp2p-webrtc-star") for Libp2pWebrtcStarAddr,
-    276 => Libp2pWebrtcDirect("libp2p-webrtc-direct") for Libp2pWebrtcDirectAddr
+    275 => Libp2pWebrtcStar("libp2p-webrtc-star") for Libp2pWebrtcStarSegment,
+    276 => Libp2pWebrtcDirect("libp2p-webrtc-direct") for Libp2pWebrtcDirectSegment
 );
 
 
@@ -714,10 +714,10 @@ impl Protocol {
     /// assert_eq!(proto.string_to_bytes("127.0.0.1").unwrap(), [127, 0, 0, 1]);
     /// ```
     ///
-    #[deprecated(note = "Use `Addr::from_protocol_str` and `.to_bytes()` instead")]
+    #[deprecated(note = "Use `Segment::from_protocol_str` and `.data_to_stream()` instead")]
     pub fn string_to_bytes(&self, a: &str) -> Result<Vec<u8>> {
         let mut vec = Vec::new();
-        Addr::from_protocol_str(*self, a)?.data_to_stream(&mut vec).unwrap();
+        Segment::from_protocol_str(*self, a)?.data_to_stream(&mut vec).unwrap();
         Ok(vec)
     }
 
@@ -738,11 +738,11 @@ impl Protocol {
     /// If there is no address representation for the protocol, like for `https`
     /// then `None` is returned.
     ///
-    #[deprecated(note = "Use `Addr::from_protocol_stream` and `.to_string()` instead")]
+    #[deprecated(note = "Use `Segment::from_protocol_stream` and `.to_string()` instead")]
     pub fn bytes_to_string(&self, b: &[u8]) -> Result<Option<String>> {
         let mut cursor = Cursor::new(b);
 
-        let string = Addr::from_protocol_stream(*self, &mut cursor)?.to_string();
+        let string = Segment::from_protocol_stream(*self, &mut cursor)?.to_string();
         if string.len() < 1 {
             Ok(None)
         } else {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,5 @@
 extern crate multiaddr;
+extern crate cid;
 extern crate data_encoding;
 
 use data_encoding::hex;
@@ -16,14 +17,22 @@ fn protocol_to_name() {
 }
 
 
-fn assert_bytes(source: &str, target: &str, protocols: Vec<Protocol>) -> () {
-    let address = Multiaddr::new(source).unwrap();
-    assert_eq!(hex::encode(address.to_bytes().as_slice()), target);
-    assert_eq!(address.protocol(), protocols);
-}
-fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol>) -> () {
-    assert_bytes(source, target, protocols);
-    assert_eq!(Multiaddr::new(source).unwrap().to_string(), source);
+#[allow(deprecated)]
+fn ma_valid(source: &str, target: &str, segments: &[Segment]) -> () {
+	// Create MultiAddr from string
+	let address = Multiaddr::new(source).unwrap();
+	
+	// Serialize MultiAddr to string and verify that it matches the original string
+	assert_eq!(address.to_string(), source);
+	
+	// Serialize MultiAddr to bytes and compare with the expected value
+	assert_eq!(hex::encode(address.to_bytes().as_slice()), target);
+	
+	// Validate that the parsed MultiAddr representation matches the expected values
+	assert_eq!(address.segments(), segments);
+	
+	// Test the deprecated `.protocol()` API
+	assert_eq!(address.protocol(), address.segments().iter().map(|s: &Segment| s.protocol()).collect::<Vec<Protocol>>());
 }
 
 #[test]
@@ -43,66 +52,108 @@ fn multiaddr_eq() {
 
 #[test]
 fn construct_success() {
-    use Protocol::*;
-
-    ma_valid("/ip4/1.2.3.4", "0401020304", vec![IP4]);
-    ma_valid("/ip4/0.0.0.0", "0400000000", vec![IP4]);
-    ma_valid("/ip6/::1", "2900000000000000000000000000000001", vec![IP6]);
-    ma_valid("/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21",
-             "29260100094F819700803ECA6566E80C21",
-             vec![IP6]);
-    ma_valid("/udp/0", "110000", vec![UDP]);
-    ma_valid("/tcp/0", "060000", vec![TCP]);
-    ma_valid("/sctp/0", "84010000", vec![SCTP]);
-    ma_valid("/udp/1234", "1104D2", vec![UDP]);
-    ma_valid("/tcp/1234", "0604D2", vec![TCP]);
-    ma_valid("/sctp/1234", "840104D2", vec![SCTP]);
-    ma_valid("/udp/65535", "11FFFF", vec![UDP]);
-    ma_valid("/tcp/65535", "06FFFF", vec![TCP]);
-    ma_valid("/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-             "A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
-             vec![IPFS]);
-    ma_valid("/udp/1234/sctp/1234", "1104D2840104D2", vec![UDP, SCTP]);
-    ma_valid("/udp/1234/udt", "1104D2AD02", vec![UDP, UDT]);
-    ma_valid("/udp/1234/utp", "1104D2AE02", vec![UDP, UTP]);
-    ma_valid("/tcp/1234/http", "0604D2E003", vec![TCP, HTTP]);
-    ma_valid("/tcp/1234/https", "0604D2BB03", vec![TCP, HTTPS]);
-    ma_valid("/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
-             "A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",
-             vec![IPFS, TCP]);
-    ma_valid("/ip4/127.0.0.1/udp/1234",
-             "047F0000011104D2",
-             vec![IP4, UDP]);
-    ma_valid("/ip4/127.0.0.1/udp/0", "047F000001110000", vec![IP4, UDP]);
-    ma_valid("/ip4/127.0.0.1/tcp/1234",
-             "047F0000010604D2",
-             vec![IP4, TCP]);
-    ma_valid("/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-             "047F000001A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
-             vec![IP4, IPFS]);
-    ma_valid("/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
-             "047F000001A503221220D52EBB89D85B02A284948203A\
-62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",
-             vec![IP4, IPFS, TCP]);
-    // /unix/a/b/c/d/e,
-    // /unix/stdio,
-    // /ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f,
-    // /ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio
-    ma_valid("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:\
-              7095/tcp/8000/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-             "29200108A07AC542013AC986FFFE317095061F40DD03A5\
-03221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
-             vec![IP6, TCP, WS, IPFS]);
-    ma_valid("/libp2p-webrtc-star/ip4/127.0.0.\
-              1/tcp/9090/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-             "9302047F000001062382DD03A503221220D52EBB89D85B\
-02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
-             vec![Libp2pWebrtcStar, IP4, TCP, WS, IPFS]);
-    ma_valid("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:\
-              7095/tcp/8000/wss/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-             "29200108A07AC542013AC986FFFE317095061F40DE03A503221220D52EBB8\
-9D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
-             vec![IP6, TCP, WSS, IPFS]);
+	use protocol::*;
+	
+	ma_valid("/ip4/1.2.3.4", "0401020304",
+		&[Segment::IP4(IP4Segment(Ipv4Addr::new(1, 2, 3, 4)))]
+	);
+	ma_valid("/ip4/0.0.0.0", "0400000000",
+		&[Segment::IP4(IP4Segment(Ipv4Addr::new(0, 0, 0, 0)))]
+	);
+	ma_valid("/ip6/::1", "2900000000000000000000000000000001",
+		&[Segment::IP6(IP6Segment(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))]
+	);
+	ma_valid("/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21",
+		"29260100094F819700803ECA6566E80C21",
+		&[Segment::IP6(IP6Segment(Ipv6Addr::new(0x2601, 0x9, 0x4f81, 0x9700, 0x803e, 0xca65, 0x66e8, 0xc21)))]
+	);
+	
+	ma_valid("/udp/0", "110000", &[Segment::UDP(UDPSegment(0))]);
+	ma_valid("/tcp/0", "060000", &[Segment::TCP(TCPSegment(0))]);
+	ma_valid("/sctp/0", "84010000", &[Segment::SCTP(SCTPSegment(0))]);
+	ma_valid("/udp/1234", "1104D2", &[Segment::UDP(UDPSegment(1234))]);
+	ma_valid("/tcp/1234", "0604D2", &[Segment::TCP(TCPSegment(1234))]);
+	ma_valid("/sctp/1234", "840104D2", &[Segment::SCTP(SCTPSegment(1234))]);
+	ma_valid("/udp/65535", "11FFFF", &[Segment::UDP(UDPSegment(65535))]);
+	ma_valid("/tcp/65535", "06FFFF", &[Segment::TCP(TCPSegment(65535))]);
+	
+	
+	
+	ma_valid("/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+		"A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+		&[Segment::IPFS(IPFSSegment(cid::Cid::from("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC").unwrap()))]
+	);
+	ma_valid("/udp/1234/sctp/1234", "1104D2840104D2",
+		&[Segment::UDP(UDPSegment(1234)), Segment::SCTP(SCTPSegment(1234))]
+	);
+	ma_valid("/udp/1234/udt", "1104D2AD02",
+		&[Segment::UDP(UDPSegment(1234)), Segment::UDT(UDTSegment {})]
+	);
+	ma_valid("/udp/1234/utp", "1104D2AE02",
+		&[Segment::UDP(UDPSegment(1234)), Segment::UTP(UTPSegment {})]
+	);
+	ma_valid("/tcp/1234/http", "0604D2E003",
+		&[Segment::TCP(TCPSegment(1234)), Segment::HTTP(HTTPSegment {})]
+	);
+	ma_valid("/tcp/1234/https", "0604D2BB03",
+		&[Segment::TCP(TCPSegment(1234)), Segment::HTTPS(HTTPSSegment {})]
+	);
+	
+	ma_valid("/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+		"A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",
+		&[Segment::IPFS(IPFSSegment(cid::Cid::from("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC").unwrap())),
+		  Segment::TCP(TCPSegment(1234))]
+	);
+	ma_valid("/ip4/127.0.0.1/udp/1234", "047F0000011104D2",
+		&[Segment::IP4(IP4Segment(Ipv4Addr::new(127, 0, 0, 1))),
+		  Segment::UDP(UDPSegment(1234))]
+	);
+	ma_valid("/ip4/127.0.0.1/udp/0", "047F000001110000",
+		&[Segment::IP4(IP4Segment(Ipv4Addr::new(127, 0, 0, 1))),
+		  Segment::UDP(UDPSegment(0))]
+	);
+	ma_valid("/ip4/127.0.0.1/tcp/1234", "047F0000010604D2",
+		&[Segment::IP4(IP4Segment(Ipv4Addr::new(127, 0, 0, 1))),
+		  Segment::TCP(TCPSegment(1234))]
+	);
+	ma_valid("/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+		"047F000001A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+		&[Segment::IP4(IP4Segment(Ipv4Addr::new(127, 0, 0, 1))),
+		  Segment::IPFS(IPFSSegment(cid::Cid::from("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC").unwrap()))]
+	);
+	ma_valid("/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+		"047F000001A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",
+		&[Segment::IP4(IP4Segment(Ipv4Addr::new(127, 0, 0, 1))),
+		  Segment::IPFS(IPFSSegment(cid::Cid::from("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC").unwrap())),
+		  Segment::TCP(TCPSegment(1234))]
+	);
+	
+	// /unix/a/b/c/d/e,
+	// /unix/stdio,
+	// /ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f,
+	// /ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio
+	ma_valid("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+		"29200108A07AC542013AC986FFFE317095061F40DD03A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+		&[Segment::IP6(IP6Segment(Ipv6Addr::new(0x2001, 0x8a0, 0x7ac5, 0x4201, 0x3ac9, 0x86ff, 0xfe31, 0x7095))),
+		  Segment::TCP(TCPSegment(8000)),
+		  Segment::WS(WSSegment {}),
+		  Segment::IPFS(IPFSSegment(cid::Cid::from("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC").unwrap()))]
+	);
+	ma_valid("/libp2p-webrtc-star/ip4/127.0.0.1/tcp/9090/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+		"9302047F000001062382DD03A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+		&[Segment::Libp2pWebrtcStar(Libp2pWebrtcStarSegment {}),
+		  Segment::IP4(IP4Segment(Ipv4Addr::new(127, 0, 0, 1))),
+		  Segment::TCP(TCPSegment(9090)),
+		  Segment::WS(WSSegment {}),
+		  Segment::IPFS(IPFSSegment(cid::Cid::from("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC").unwrap()))]
+	);
+	ma_valid("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/wss/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+		"29200108A07AC542013AC986FFFE317095061F40DE03A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+		&[Segment::IP6(IP6Segment(Ipv6Addr::new(0x2001, 0x8a0, 0x7ac5, 0x4201, 0x3ac9, 0x86ff, 0xfe31, 0x7095))),
+		  Segment::TCP(TCPSegment(8000)),
+		  Segment::WSS(WSSSegment {}),
+		  Segment::IPFS(IPFSSegment(cid::Cid::from("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC").unwrap()))]
+	);
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,10 +26,14 @@ fn ma_valid(source: &str, target: &str, segments: &[Segment]) -> () {
 	assert_eq!(address.to_string(), source);
 	
 	// Serialize MultiAddr to bytes and compare with the expected value
-	assert_eq!(hex::encode(address.to_bytes().as_slice()), target);
+	let bytes = address.to_bytes();
+	assert_eq!(hex::encode(bytes.as_slice()), target);
 	
 	// Validate that the parsed MultiAddr representation matches the expected values
 	assert_eq!(address.segments(), segments);
+	
+	// Validate that the parsed MultiAddr matches the original address
+	assert_eq!(bytes.to_multiaddr().unwrap(), address);
 	
 	// Test the deprecated `.protocol()` API
 	assert_eq!(address.protocol(), address.segments().iter().map(|s: &Segment| s.protocol()).collect::<Vec<Protocol>>());


### PR DESCRIPTION
This PR rewrites most of `src/protocol.rs` to provide a companion type for each variant of `protocol::Protocol` that can store a fully deserialized representation of the given address segment's data.

Known caveats:

  1. The `protocol::IPFSSegment` type is pretty verbose because it has to replicate some functionality from the `cid` crate that is not exposed in a reusable way
  2. The `Multiaddr` main struct also needs to carry a (useless) field with the serialized byte representation of the struct to ensure backwards-compatiblity with the `.as_slice()` method
  3. The `Protocol` and `Segment` enumerations feel somewhat redundant, but I can't think of any good way of unifying them without starting to work around the type system.
  4. Needs tests for new features!

(4) will be fixed
(1) I will propably fix at the source myself as well
(2) can be fixed any time if you're willing to break backward-compatibility

Any other comments about the code, approach, etc.?