### PR TITLE
Added Onion address support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,4 @@ version = "0.3.1"
 byteorder = "1.0"
 cid = "~0.3"
 integer-encoding = "1.0.3"
-
-[dev-dependencies]
 data-encoding = "2.0.0"

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -1,0 +1,1 @@
+pub mod onion;

--- a/src/encoding/onion.rs
+++ b/src/encoding/onion.rs
@@ -1,0 +1,129 @@
+use crate::Error;
+use byteorder::{BigEndian, ReadBytesExt};
+use data_encoding::BASE32;
+use std::{
+    fmt,
+    io::{Cursor, Read, Write},
+    str::FromStr,
+};
+
+struct OnionEncoding;
+
+impl OnionEncoding {
+    pub fn decode_v1(bytes: &[u8]) -> Result<(String, u16), Error> {
+        let mut c = Cursor::new(&bytes);
+        let mut addr_buf = [0; 10];
+        c.read_exact(&mut addr_buf)?;
+        let decoded = BASE32.encode(&addr_buf);
+        let port = c.read_u16::<BigEndian>()?;
+        Ok((decoded, port))
+    }
+
+    fn decode_v3(bytes: &[u8]) -> Result<(String, u16), Error> {
+        let mut c = Cursor::new(&bytes);
+        let mut addr_buf = [0; 35];
+        c.read_exact(&mut addr_buf)?;
+        let decoded = BASE32.encode(&addr_buf);
+        let port = c.read_u16::<BigEndian>()?;
+        Ok((decoded, port))
+    }
+
+    fn from_v1_str(s: &str) -> Result<OnionAddress, Error> {
+        let bytes = Self::from_str(s, 16)?;
+        Ok(OnionAddress { bytes })
+    }
+
+    fn from_v3_str(s: &str) -> Result<Onion3Address, Error> {
+        let bytes = Self::from_str(s, 56)?;
+        Ok(Onion3Address { bytes })
+    }
+
+    fn from_str(s: &str, expected_addr_len: usize) -> Result<Vec<u8>, Error> {
+        let parts = s.split(':').collect::<Vec<_>>();
+        if parts.len() != 2 {
+            return Err(Error::ParsingError(
+                format!("{} does not contain a port number.", s).into(),
+            ));
+        }
+
+        if parts[0].len() != expected_addr_len {
+            return Err(Error::ParsingError(format!("{} is not a Tor onion address.", s).into()));
+        }
+
+        let onion_host_bytes = BASE32.decode(&parts[0].to_ascii_uppercase().as_bytes())?;
+
+        let port: u16 = parts[1].parse()?;
+        if port < 1 {
+            return Err(Error::ParsingError("port is less than 1".into()));
+        }
+        let port_bytes = port.to_be_bytes();
+
+        let mut bytes = Vec::with_capacity(onion_host_bytes.len() + 2);
+        bytes.write_all(&onion_host_bytes)?;
+        bytes.write_all(&port_bytes)?;
+
+        Ok(bytes)
+    }
+}
+
+pub struct OnionAddress {
+    bytes: Vec<u8>,
+}
+
+impl OnionAddress {
+    pub fn from_unchecked_bytes<B: AsRef<[u8]>>(bytes: B) -> Self {
+        Self {
+            bytes: bytes.as_ref().to_vec(),
+        }
+    }
+
+    pub fn decode(&self) -> Result<(String, u16), Error> {
+        OnionEncoding::decode_v1(&self.bytes)
+    }
+}
+
+impl FromStr for OnionAddress {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        OnionEncoding::from_v1_str(s)
+    }
+}
+
+impl fmt::Display for OnionAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let (addr, port) = OnionEncoding::decode_v1(&self.bytes).map_err(|_| fmt::Error)?;
+        write!(f, "{}:{}", addr.to_ascii_lowercase(), port)
+    }
+}
+
+pub struct Onion3Address {
+    bytes: Vec<u8>,
+}
+
+impl Onion3Address {
+    pub fn from_unchecked_bytes<B: AsRef<[u8]>>(bytes: B) -> Self {
+        Self {
+            bytes: bytes.as_ref().to_vec(),
+        }
+    }
+
+    pub fn decode(&self) -> Result<(String, u16), Error> {
+        OnionEncoding::decode_v3(&self.bytes)
+    }
+}
+
+impl FromStr for Onion3Address {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        OnionEncoding::from_v3_str(s)
+    }
+}
+
+impl fmt::Display for Onion3Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let (addr, port) = OnionEncoding::decode_v3(&self.bytes).map_err(|_| fmt::Error)?;
+        write!(f, "{}:{}", addr.to_ascii_lowercase(), port)
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,7 +10,7 @@ pub enum Error {
     UnknownProtocolString,
     InvalidMultiaddr,
     MissingAddress,
-    ParsingError(Box<error::Error + Send + Sync>),
+    ParsingError(Box<dyn error::Error + Send + Sync>),
 }
 
 impl fmt::Display for Error {
@@ -31,7 +31,7 @@ impl error::Error for Error {
     }
 
     #[inline]
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::ParsingError(ref err) => Some(&**err),
             _ => None,
@@ -65,6 +65,18 @@ impl From<num::ParseIntError> for Error {
 
 impl From<string::FromUtf8Error> for Error {
     fn from(err: string::FromUtf8Error) -> Error {
+        Error::ParsingError(err.into())
+    }
+}
+
+impl From<data_encoding::DecodeError> for Error {
+    fn from(err: data_encoding::DecodeError) -> Error {
+        Error::ParsingError(err.into())
+    }
+}
+
+impl From<String> for Error {
+    fn from(err: String) -> Error {
         Error::ParsingError(err.into())
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,18 +1,24 @@
+use crate::encoding::onion::OnionAddress;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use cid::Cid;
+use data_encoding::BASE32;
+use encoding::onion::Onion3Address;
 use integer_encoding::{VarInt, VarIntWriter};
-use std::convert::From;
-use std::io::{Cursor, Result as IoResult, Write};
-use std::net::{Ipv4Addr, Ipv6Addr};
-use std::fmt;
-use std::str::FromStr;
+use std::{
+    convert::From,
+    fmt,
+    io,
+    io::{Cursor, Result as IoResult, Write},
+    net::{Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
+use Error;
+use Result;
 
-use {Error, Result};
-
-///! # Protocol
-///!
-///! A type to describe the possible protocol used in a
-///! Multiaddr.
+/// ! # Protocol
+/// !
+/// ! A type to describe the possible protocol used in a
+/// ! Multiaddr.
 
 /// Protocol is the list of all possible protocols.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -34,6 +40,7 @@ pub enum Protocol {
     HTTP = 480,
     HTTPS = 443,
     ONION = 444,
+    ONION3 = 445,
     QUIC = 460,
     WS = 477,
     WSS = 478,
@@ -74,6 +81,7 @@ impl fmt::Display for Protocol {
             Protocol::HTTP => "http",
             Protocol::HTTPS => "https",
             Protocol::ONION => "onion",
+            Protocol::ONION3 => "onion3",
             Protocol::QUIC => "quic",
             Protocol::WS => "ws",
             Protocol::WSS => "wss",
@@ -106,6 +114,7 @@ impl FromStr for Protocol {
             "http" => Ok(Protocol::HTTP),
             "https" => Ok(Protocol::HTTPS),
             "onion" => Ok(Protocol::ONION),
+            "onion3" => Ok(Protocol::ONION3),
             "quic" => Ok(Protocol::QUIC),
             "ws" => Ok(Protocol::WS),
             "wss" => Ok(Protocol::WSS),
@@ -147,6 +156,7 @@ impl Protocol {
             480 => Ok(Protocol::HTTP),
             443 => Ok(Protocol::HTTPS),
             444 => Ok(Protocol::ONION),
+            445 => Ok(Protocol::ONION3),
             460 => Ok(Protocol::QUIC),
             477 => Ok(Protocol::WS),
             478 => Ok(Protocol::WSS),
@@ -163,12 +173,10 @@ impl Protocol {
     /// # Examples
     ///
     /// ```
-    /// use multiaddr::Protocol;
-    /// use multiaddr::ProtocolArgSize;
+    /// use multiaddr::{Protocol, ProtocolArgSize};
     ///
     /// assert_eq!(Protocol::TCP.size(), ProtocolArgSize::Fixed { bytes: 2 });
     /// ```
-    ///
     pub fn size(self) -> ProtocolArgSize {
         match self {
             Protocol::IP4 => ProtocolArgSize::Fixed { bytes: 4 },
@@ -186,7 +194,8 @@ impl Protocol {
             Protocol::IPFS => ProtocolArgSize::Variable,
             Protocol::HTTP => ProtocolArgSize::Fixed { bytes: 0 },
             Protocol::HTTPS => ProtocolArgSize::Fixed { bytes: 0 },
-            Protocol::ONION => ProtocolArgSize::Fixed { bytes: 10 },
+            Protocol::ONION => ProtocolArgSize::Fixed { bytes: 12 },
+            Protocol::ONION3 => ProtocolArgSize::Fixed { bytes: 37 },
             Protocol::QUIC => ProtocolArgSize::Fixed { bytes: 0 },
             Protocol::WS => ProtocolArgSize::Fixed { bytes: 0 },
             Protocol::WSS => ProtocolArgSize::Fixed { bytes: 0 },
@@ -213,52 +222,59 @@ impl Protocol {
     /// # Examples
     ///
     /// ```
+    /// use multiaddr::{AddrComponent, Protocol};
     /// use std::net::Ipv4Addr;
-    /// use multiaddr::AddrComponent;
-    /// use multiaddr::Protocol;
     ///
     /// let proto = Protocol::IP4;
-    /// assert_eq!(proto.parse_data("127.0.0.1").unwrap(),
-    ///            AddrComponent::IP4(Ipv4Addr::new(127, 0, 0, 1)));
+    /// assert_eq!(
+    ///     proto.parse_data("127.0.0.1").unwrap(),
+    ///     AddrComponent::IP4(Ipv4Addr::new(127, 0, 0, 1))
+    /// );
     /// ```
-    ///
     pub fn parse_data(&self, a: &str) -> Result<AddrComponent> {
         match *self {
             Protocol::IP4 => {
                 let addr = Ipv4Addr::from_str(a)?;
                 Ok(AddrComponent::IP4(addr))
-            }
+            },
             Protocol::IP6 => {
                 let addr = Ipv6Addr::from_str(a)?;
                 Ok(AddrComponent::IP6(addr))
-            }
+            },
             Protocol::DNS4 => Ok(AddrComponent::DNS4(a.to_owned())),
             Protocol::DNS6 => Ok(AddrComponent::DNS6(a.to_owned())),
             Protocol::TCP => {
                 let parsed: u16 = a.parse()?;
                 Ok(AddrComponent::TCP(parsed))
-            }
+            },
             Protocol::UDP => {
                 let parsed: u16 = a.parse()?;
                 Ok(AddrComponent::UDP(parsed))
-            }
+            },
             Protocol::DCCP => {
                 let parsed: u16 = a.parse()?;
                 Ok(AddrComponent::DCCP(parsed))
-            }
+            },
             Protocol::SCTP => {
                 let parsed: u16 = a.parse()?;
                 Ok(AddrComponent::SCTP(parsed))
-            }
+            },
             Protocol::P2P => {
                 let bytes = Cid::from(a)?.to_bytes();
                 Ok(AddrComponent::P2P(bytes))
-            }
+            },
             Protocol::IPFS => {
                 let bytes = Cid::from(a)?.to_bytes();
                 Ok(AddrComponent::IPFS(bytes))
-            }
-            Protocol::ONION => unimplemented!(), // TODO:
+            },
+            Protocol::ONION => {
+                let (addr, port) = OnionAddress::from_str(a)?.decode()?;
+                Ok(AddrComponent::ONION(addr, port))
+            },
+            Protocol::ONION3 => {
+                let (addr, port) = Onion3Address::from_str(a)?.decode()?;
+                Ok(AddrComponent::ONION3(addr, port))
+            },
             Protocol::QUIC => Ok(AddrComponent::QUIC),
             Protocol::UTP => Ok(AddrComponent::UTP),
             Protocol::UNIX => Ok(AddrComponent::UNIX(a.to_owned())),
@@ -292,7 +308,8 @@ pub enum AddrComponent {
     IPFS(Vec<u8>),
     HTTP,
     HTTPS,
-    ONION(Vec<u8>),
+    ONION(String, u16),
+    ONION3(String, u16),
     QUIC,
     WS,
     WSS,
@@ -322,7 +339,8 @@ impl AddrComponent {
             AddrComponent::IPFS(_) => Protocol::IPFS,
             AddrComponent::HTTP => Protocol::HTTP,
             AddrComponent::HTTPS => Protocol::HTTPS,
-            AddrComponent::ONION(_) => Protocol::ONION,
+            AddrComponent::ONION(_, _) => Protocol::ONION,
+            AddrComponent::ONION3(_, _) => Protocol::ONION3,
             AddrComponent::QUIC => Protocol::QUIC,
             AddrComponent::WS => Protocol::WS,
             AddrComponent::WSS => Protocol::WSS,
@@ -344,7 +362,7 @@ impl AddrComponent {
             ProtocolArgSize::Variable => {
                 let (data_size, varint_len) = u64::decode_var(&input[proto_id_len..]); // TODO: will panic if ID too large
                 (varint_len, data_size as usize)
-            }
+            },
         };
 
         let (data, rest) = input[proto_id_len..][data_offset..].split_at(data_size);
@@ -359,43 +377,48 @@ impl AddrComponent {
                     seg.push(rdr.read_u16::<BigEndian>()?);
                 }
 
-                let addr = Ipv6Addr::new(
-                    seg[0], seg[1], seg[2], seg[3], seg[4], seg[5], seg[6], seg[7],
-                );
+                let addr = Ipv6Addr::new(seg[0], seg[1], seg[2], seg[3], seg[4], seg[5], seg[6], seg[7]);
                 AddrComponent::IP6(addr)
-            }
+            },
             Protocol::DNS4 => AddrComponent::DNS4(String::from_utf8(data.to_owned())?),
             Protocol::DNS6 => AddrComponent::DNS6(String::from_utf8(data.to_owned())?),
             Protocol::TCP => {
                 let mut rdr = Cursor::new(data);
                 let num = rdr.read_u16::<BigEndian>()?;
                 AddrComponent::TCP(num)
-            }
+            },
             Protocol::UDP => {
                 let mut rdr = Cursor::new(data);
                 let num = rdr.read_u16::<BigEndian>()?;
                 AddrComponent::UDP(num)
-            }
+            },
             Protocol::DCCP => {
                 let mut rdr = Cursor::new(data);
                 let num = rdr.read_u16::<BigEndian>()?;
                 AddrComponent::DCCP(num)
-            }
+            },
             Protocol::SCTP => {
                 let mut rdr = Cursor::new(data);
                 let num = rdr.read_u16::<BigEndian>()?;
                 AddrComponent::SCTP(num)
-            }
+            },
             Protocol::UNIX => AddrComponent::UNIX(String::from_utf8(data.to_owned())?),
             Protocol::P2P => {
                 let bytes = Cid::from(data)?.to_bytes();
                 AddrComponent::P2P(bytes)
-            }
+            },
             Protocol::IPFS => {
                 let bytes = Cid::from(data)?.to_bytes();
                 AddrComponent::IPFS(bytes)
-            }
-            Protocol::ONION => unimplemented!(), // TODO:
+            },
+            Protocol::ONION => {
+                let (addr, port) = OnionAddress::from_unchecked_bytes(data).decode()?;
+                AddrComponent::ONION(addr, port)
+            },
+            Protocol::ONION3 => {
+                let (addr, port) = Onion3Address::from_unchecked_bytes(data).decode()?;
+                AddrComponent::ONION3(addr, port)
+            },
             Protocol::QUIC => AddrComponent::QUIC,
             Protocol::UTP => AddrComponent::UTP,
             Protocol::UDT => AddrComponent::UDT,
@@ -419,41 +442,45 @@ impl AddrComponent {
         match self {
             AddrComponent::IP4(addr) => {
                 out.write_all(&addr.octets())?;
-            }
+            },
             AddrComponent::IP6(addr) => {
                 for &segment in &addr.segments() {
                     out.write_u16::<BigEndian>(segment)?;
                 }
-            }
-            AddrComponent::TCP(port)
-            | AddrComponent::UDP(port)
-            | AddrComponent::DCCP(port)
-            | AddrComponent::SCTP(port) => {
+            },
+            AddrComponent::TCP(port) |
+            AddrComponent::UDP(port) |
+            AddrComponent::DCCP(port) |
+            AddrComponent::SCTP(port) => {
                 out.write_u16::<BigEndian>(port)?;
-            }
+            },
             AddrComponent::DNS4(s) | AddrComponent::DNS6(s) | AddrComponent::UNIX(s) => {
                 let bytes = s.as_bytes();
                 out.write_varint(bytes.len())?;
                 out.write_all(&bytes)?;
-            }
+            },
             AddrComponent::P2P(bytes) | AddrComponent::IPFS(bytes) => {
                 out.write_varint(bytes.len())?;
                 out.write_all(&bytes)?;
-            }
-            AddrComponent::ONION(_) => {
-                unimplemented!() // TODO:
-            }
-            AddrComponent::QUIC
-            | AddrComponent::UTP
-            | AddrComponent::UDT
-            | AddrComponent::HTTP
-            | AddrComponent::HTTPS
-            | AddrComponent::WS
-            | AddrComponent::WSS
-            | AddrComponent::Libp2pWebsocketStar
-            | AddrComponent::Libp2pWebrtcStar
-            | AddrComponent::Libp2pWebrtcDirect
-            | AddrComponent::P2pCircuit => {}
+            },
+            AddrComponent::ONION(addr, port) | AddrComponent::ONION3(addr, port) => {
+                let decoded = BASE32
+                    .decode(addr.as_bytes())
+                    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+                out.write_all(&decoded)?;
+                out.write_u16::<BigEndian>(port)?;
+            },
+            AddrComponent::QUIC |
+            AddrComponent::UTP |
+            AddrComponent::UDT |
+            AddrComponent::HTTP |
+            AddrComponent::HTTPS |
+            AddrComponent::WS |
+            AddrComponent::WSS |
+            AddrComponent::Libp2pWebsocketStar |
+            AddrComponent::Libp2pWebrtcStar |
+            AddrComponent::Libp2pWebrtcDirect |
+            AddrComponent::P2pCircuit => {},
         };
 
         Ok(())
@@ -468,25 +495,24 @@ impl fmt::Display for AddrComponent {
             AddrComponent::UDP(port) => write!(f, "/udp/{}", port),
             AddrComponent::DCCP(port) => write!(f, "/dccp/{}", port),
             AddrComponent::IP6(addr) => write!(f, "/ip6/{}", addr),
-            AddrComponent::DNS4(s) => write!(f, "/dns4/{}", s.clone()),
-            AddrComponent::DNS6(s) => write!(f, "/dns6/{}", s.clone()),
+            AddrComponent::DNS4(s) => write!(f, "/dns4/{}", s),
+            AddrComponent::DNS6(s) => write!(f, "/dns6/{}", s),
             AddrComponent::SCTP(port) => write!(f, "/sctp/{}", port),
             AddrComponent::UDT => write!(f, "/udt"),
             AddrComponent::UTP => write!(f, "/utp"),
-            AddrComponent::UNIX(s) => write!(f, "/unix/{}", s.clone()),
+            AddrComponent::UNIX(s) => write!(f, "/unix/{}", s),
             AddrComponent::P2P(bytes) => {
-                // TODO: meh for cloning
-                let c = Cid::from(bytes.clone()).expect("cid is known to be valid");
+                let c = Cid::from(bytes.as_slice()).expect("cid is known to be valid");
                 write!(f, "/p2p/{}", c)
-            }
+            },
             AddrComponent::IPFS(bytes) => {
-                // TODO: meh for cloning
-                let c = Cid::from(bytes.clone()).expect("cid is known to be valid");
+                let c = Cid::from(bytes.as_slice()).expect("cid is known to be valid");
                 write!(f, "/ipfs/{}", c)
-            }
+            },
             AddrComponent::HTTP => write!(f, "/http"),
             AddrComponent::HTTPS => write!(f, "/https"),
-            AddrComponent::ONION(_) => unimplemented!(), //format!("/onion"),        // TODO:
+            AddrComponent::ONION(addr, port) => write!(f, "/onion/{}:{}", addr.to_ascii_lowercase(), port),
+            AddrComponent::ONION3(addr, port) => write!(f, "/onion3/{}:{}", addr.to_ascii_lowercase(), port),
             AddrComponent::QUIC => write!(f, "/quic"),
             AddrComponent::WS => write!(f, "/ws"),
             AddrComponent::WSS => write!(f, "/wss"),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -19,10 +19,7 @@ fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol>) {
     let parsed = source.parse::<Multiaddr>().unwrap();
     assert_eq!(HEXUPPER.encode(parsed.to_bytes().as_slice()), target);
     assert_eq!(
-        parsed
-            .iter()
-            .map(|addr| addr.protocol_id())
-            .collect::<Vec<_>>(),
+        parsed.iter().map(|addr| addr.protocol_id()).collect::<Vec<_>>(),
         protocols
     );
     assert_eq!(source.parse::<Multiaddr>().unwrap().to_string(), source);
@@ -79,17 +76,9 @@ fn construct_success() {
         "A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",
         vec![IPFS, TCP],
     );
-    ma_valid(
-        "/ip4/127.0.0.1/udp/1234",
-        "047F000001910204D2",
-        vec![IP4, UDP],
-    );
+    ma_valid("/ip4/127.0.0.1/udp/1234", "047F000001910204D2", vec![IP4, UDP]);
     ma_valid("/ip4/127.0.0.1/udp/0", "047F00000191020000", vec![IP4, UDP]);
-    ma_valid(
-        "/ip4/127.0.0.1/tcp/1234",
-        "047F0000010604D2",
-        vec![IP4, TCP],
-    );
+    ma_valid("/ip4/127.0.0.1/tcp/1234", "047F0000010604D2", vec![IP4, TCP]);
     ma_valid(
         "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
         "047F000001A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
@@ -97,8 +86,7 @@ fn construct_success() {
     );
     ma_valid(
         "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
-        "047F000001A503221220D52EBB89D85B02A284948203A\
-         62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",
+        "047F000001A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",
         vec![IP4, IPFS, TCP],
     );
     // /unix/a/b/c/d/e,
@@ -113,10 +101,8 @@ fn construct_success() {
         vec![IP6, TCP, WS, IPFS],
     );
     ma_valid(
-        "/p2p-webrtc-star/ip4/127.0.0.\
-         1/tcp/9090/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-        "9302047F000001062382DD03A503221220D52EBB89D85B\
-         02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+        "/p2p-webrtc-star/ip4/127.0.0.1/tcp/9090/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+        "9302047F000001062382DD03A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
         vec![Libp2pWebrtcStar, IP4, TCP, WS, IPFS],
     );
     ma_valid(
@@ -128,9 +114,23 @@ fn construct_success() {
     );
     ma_valid(
         "/ip4/127.0.0.1/tcp/9090/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-        "047F000001062382A202A503221220D52EBB89D85B\
-         02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+        "047F000001062382A202A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
         vec![IP4, TCP, P2pCircuit, IPFS],
+    );
+
+    ma_valid("/onion/aaimaq4ygg2iegci:80", "BC030010C0439831B48218480050", vec![
+        ONION,
+    ]);
+    ma_valid(
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234",
+        "BD03ADADEC040BE047F9658668B11A504F3155001F231A37F54C4476C07FB4CC139ED7E30304D2",
+        vec![ONION3],
+    );
+
+    ma_valid(
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:80/http",
+        "BD03ADADEC040BE047F9658668B11A504F3155001F231A37F54C4476C07FB4CC139ED7E3030050E003",
+        vec![ONION3, HTTP],
     );
 }
 
@@ -146,12 +146,18 @@ fn construct_fail() {
         "/sctp",
         "/udp/65536",
         "/tcp/65536",
-        // "/onion/9imaq4ygg2iegci7:80",
-        // "/onion/aaimaq4ygg2iegci7:80",
-        // "/onion/timaq4ygg2iegci7:0",
-        // "/onion/timaq4ygg2iegci7:-1",
-        // "/onion/timaq4ygg2iegci7",
-        // "/onion/timaq4ygg2iegci@:666",
+        "/onion/9imaq4ygg2iegci7:80",
+        "/onion/aaimaq4ygg2iegci7:80",
+        "/onion/timaq4ygg2iegci7:0",
+        "/onion/timaq4ygg2iegci7:-1",
+        "/onion/timaq4ygg2iegci7",
+        "/onion/timaq4ygg2iegci@:666",
+        "/onion3/9ww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:80",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd7:80",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:0",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:-1",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyy@:666",
         "/udp/1234/sctp",
         "/udp/1234/udt/1234",
         "/udp/1234/utp/1234",
@@ -179,24 +185,15 @@ fn to_multiaddr() {
         Ipv6Addr::new(0x2601, 0x9, 0x4f81, 0x9700, 0x803e, 0xca65, 0x66e8, 0xc21)
             .to_multiaddr()
             .unwrap(),
-        "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21"
-            .parse::<Multiaddr>()
-            .unwrap()
+        "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21".parse::<Multiaddr>().unwrap()
     );
     assert_eq!(
-        "/ip4/127.0.0.1/tcp/1234"
-            .to_string()
-            .to_multiaddr()
-            .unwrap(),
+        "/ip4/127.0.0.1/tcp/1234".to_string().to_multiaddr().unwrap(),
         "/ip4/127.0.0.1/tcp/1234".parse::<Multiaddr>().unwrap()
     );
     assert_eq!(
-        "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21"
-            .to_multiaddr()
-            .unwrap(),
-        "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21"
-            .parse::<Multiaddr>()
-            .unwrap()
+        "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21".to_multiaddr().unwrap(),
+        "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21".parse::<Multiaddr>().unwrap()
     );
     assert_eq!(
         SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 1234)


### PR DESCRIPTION
Support for parsing `/onion` and `/onion3` addresses.

Unfortunately I had to make `data-encoding` a dependency because
`multibase` added an extra (padding?) byte to the byte representation
when decoding from BASE32. 

This go implementation uses go std lib base32 encoding, not multibase so perhaps this is fine.

There are probably a few issues such as whether it's acceptable to have the onion encoding code in this repo. If so, suggestions welcome :)

Progress on #3 