### PR TITLE
CHANGELOG: Prepare v0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.12.0 [unreleased]
+# 0.12.0 [2021-05-26]
 
 - Merge  [multiaddr] and [parity-multiaddr] (see [PR 40]).
 


### PR DESCRIPTION
I would like to cut a new release of the `multiaddr` crate. Any objections? Anything that is not yet in `master` that you would like to see included?
