### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ then run `cargo build`.
 ```rust
 extern crate multiaddr;
 
-use multiaddr::{Multiaddr, ToMultiaddr};
+use multiaddr::{Multiaddr, multiaddr};
 
-let address = "/ip4/127.0.0.1/udp/1234".parse::<Multiaddr>().unwrap();
-// or directly from a string
-let other = "/ip4/127.0.0.1".to_multiaddr().unwrap();
+let address = "/ip4/127.0.0.1/tcp/1234".parse::<Multiaddr>().unwrap();
+// or with a macros
+let other = multiaddr!(Ip4([127, 0, 0, 1]), Udp(10500u16), Quic);
 
-assert_eq!(address.to_string(), "/ip4/127.0.0.1/udp/1234");
-assert_eq!(other.to_string(), "/ip4/127.0.0.1");
+assert_eq!(address.to_string(), "/ip4/127.0.0.1/tcp/1234");
+assert_eq!(other.to_string(), "/ip4/127.0.0.1/udp/10500/quic");
 ```
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ extern crate multiaddr;
 use multiaddr::{Multiaddr, multiaddr};
 
 let address = "/ip4/127.0.0.1/tcp/1234".parse::<Multiaddr>().unwrap();
-// or with a macros
+// or with a macro
 let other = multiaddr!(Ip4([127, 0, 0, 1]), Udp(10500u16), Quic);
 
 assert_eq!(address.to_string(), "/ip4/127.0.0.1/tcp/1234");


### PR DESCRIPTION
There is no `ToMultiaddr` in the crate so the example in README does not compile. I fixed it and added an example of macro `multiaddr!`.