### PR TITLE
Add support for `tls` protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.0 [unreleased]
+
+- Add support for TLS protocol (see [PR 48]).
+
 # 0.13.0 [unreleased]
 
 - Update to multihash v0.14.0 (see [PR 44]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # 0.14.0 [unreleased]
 
 - Add support for TLS protocol (see [PR 48]).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["multiaddr", "ipfs"]
 license = "MIT"
 name = "multiaddr"
 readme = "README.md"
-version = "0.13.0"
+version = "0.14.0"
 
 [features]
 default = ["url"]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -14,8 +14,9 @@ use std::{
 use unsigned_varint::{encode, decode};
 use crate::onion_addr::Onion3Addr;
 
-// All these values are obtained by converting hexadecimal protocol codes to u32.
-// The protocol codes are present in multiformats/multicodec repository.
+// All the values are obtained by converting hexadecimal protocol codes to u32.
+// Protocols as well as their corresponding codes are defined in
+// https://github.com/multiformats/multiaddr/blob/master/protocols.csv .
 const DCCP: u32 = 33;
 const DNS: u32 = 53;
 const DNS4: u32 = 54;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -254,9 +254,6 @@ fn construct_success() {
         "3819736A632D312E626F6F7473747261702E6C69627032702E696F0604D2A50322122006B3608AA000274049EB28AD8E793A26FF6FAB281A7D3BD77CD18EB745DFAABB",
         vec![Dnsaddr(Cow::Borrowed("sjc-1.bootstrap.libp2p.io")), Tcp(1234), P2p(multihash("QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"))]
     );
-    // "/ip4/127.0.0.1/tcp/127/ws",
-    // "/ip4/127.0.0.1/tcp/127/tls",
-    // "/ip4/127.0.0.1/tcp/127/tls/ws",
     ma_valid("/ip4/127.0.0.1/tcp/127/ws", "047F00000106007FDD03", vec![Ip4(local.clone()),Tcp(127),Ws("/".into())] );
     ma_valid("/ip4/127.0.0.1/tcp/127/tls", "047F00000106007FC003", vec![Ip4(local.clone()),Tcp(127),Tls] );
     ma_valid("/ip4/127.0.0.1/tcp/127/tls/ws", "047F00000106007FC003DD03", vec![Ip4(local.clone()),Tcp(127),Tls,Ws("/".into())] );

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -128,6 +128,7 @@ impl Arbitrary for Proto {
                     .unwrap();
                 Proto(Onion3((a, std::cmp::max(1, u16::arbitrary(g))).into()))
             },
+            25 => Proto(Tls),
              _ => panic!("outside range")
         }
     }
@@ -253,6 +254,12 @@ fn construct_success() {
         "3819736A632D312E626F6F7473747261702E6C69627032702E696F0604D2A50322122006B3608AA000274049EB28AD8E793A26FF6FAB281A7D3BD77CD18EB745DFAABB",
         vec![Dnsaddr(Cow::Borrowed("sjc-1.bootstrap.libp2p.io")), Tcp(1234), P2p(multihash("QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"))]
     );
+    // "/ip4/127.0.0.1/tcp/127/ws",
+    // "/ip4/127.0.0.1/tcp/127/tls",
+    // "/ip4/127.0.0.1/tcp/127/tls/ws",
+    ma_valid("/ip4/127.0.0.1/tcp/127/ws", "047F00000106007FDD03", vec![Ip4(local.clone()),Tcp(127),Ws("/".into())] );
+    ma_valid("/ip4/127.0.0.1/tcp/127/tls", "047F00000106007FC003", vec![Ip4(local.clone()),Tcp(127),Tls] );
+    ma_valid("/ip4/127.0.0.1/tcp/127/tls/ws", "047F00000106007FC003DD03", vec![Ip4(local.clone()),Tcp(127),Tls,Ws("/".into())] );
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -149,11 +149,7 @@ impl Arbitrary for SubString {
 
 
 fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol<'_>>) {
-    dbg!(&source);
-    dbg!(&target);
-    dbg!(&protocols);
     let parsed = source.parse::<Multiaddr>().unwrap();
-    dbg!(&parsed);
     assert_eq!(HEXUPPER.encode(&parsed.to_vec()[..]), target);
     assert_eq!(parsed.iter().collect::<Vec<_>>(), protocols);
     assert_eq!(source.parse::<Multiaddr>().unwrap().to_string(), source);
@@ -325,9 +321,9 @@ fn from_bytes_fail() {
 
 #[test]
 fn ser_and_deser_json() {
-    let addr : Multiaddr = "/ip4/0.0.0.0/tcp/0".parse::<Multiaddr>().unwrap();
+    let addr : Multiaddr = "/ip4/0.0.0.0/tcp/0/tls".parse::<Multiaddr>().unwrap();
     let serialized = serde_json::to_string(&addr).unwrap();
-    assert_eq!(serialized, "\"/ip4/0.0.0.0/tcp/0\"");
+    assert_eq!(serialized, "\"/ip4/0.0.0.0/tcp/0/tls\"");
     let deserialized: Multiaddr = serde_json::from_str(&serialized).unwrap();
     assert_eq!(addr, deserialized);
 }
@@ -335,10 +331,10 @@ fn ser_and_deser_json() {
 
 #[test]
 fn ser_and_deser_bincode() {
-    let addr : Multiaddr = "/ip4/0.0.0.0/tcp/0".parse::<Multiaddr>().unwrap();
+    let addr : Multiaddr = "/ip4/0.0.0.0/tcp/0/tls".parse::<Multiaddr>().unwrap();
     let serialized = bincode::serialize(&addr).unwrap();
     // compact addressing
-    assert_eq!(serialized, vec![8, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 6, 0, 0]);
+    assert_eq!(serialized, vec![10, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 6, 0, 0, 192, 3]);
     let deserialized: Multiaddr = bincode::deserialize(&serialized).unwrap();
     assert_eq!(addr, deserialized);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -86,7 +86,7 @@ struct Proto(Protocol<'static>);
 impl Arbitrary for Proto {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         use Protocol::*;
-        match u8::arbitrary(g) % 25  { // TODO: Add Protocol::Quic
+        match u8::arbitrary(g) % 26  { // TODO: Add Protocol::Quic
              0 => Proto(Dccp(Arbitrary::arbitrary(g))),
              1 => Proto(Dns(Cow::Owned(SubString::arbitrary(g).0))),
              2 => Proto(Dns4(Cow::Owned(SubString::arbitrary(g).0))),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -149,7 +149,11 @@ impl Arbitrary for SubString {
 
 
 fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol<'_>>) {
+    dbg!(&source);
+    dbg!(&target);
+    dbg!(&protocols);
     let parsed = source.parse::<Multiaddr>().unwrap();
+    dbg!(&parsed);
     assert_eq!(HEXUPPER.encode(&parsed.to_vec()[..]), target);
     assert_eq!(parsed.iter().collect::<Vec<_>>(), protocols);
     assert_eq!(source.parse::<Multiaddr>().unwrap().to_string(), source);
@@ -200,6 +204,7 @@ fn construct_success() {
     ma_valid("/udp/1234/udt", "910204D2AD02", vec![Udp(1234), Udt]);
     ma_valid("/udp/1234/utp", "910204D2AE02", vec![Udp(1234), Utp]);
     ma_valid("/tcp/1234/http", "0604D2E003", vec![Tcp(1234), Http]);
+    ma_valid("/tcp/1234/tls/http", "0604D2C003E003", vec![Tcp(1234), Tls, Http]);
     ma_valid("/tcp/1234/https", "0604D2BB03", vec![Tcp(1234), Https]);
     ma_valid("/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
              "A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",


### PR DESCRIPTION
Hi @mxinden,
Creating this PR to close the issue #47.
This PR refers the Go code from [PR 153](https://github.com/multiformats/go-multiaddr/pull/153).

i have a couple of questions regarding the tests, it seems like we are missing a few tests:
1. [`construct_success`](https://github.com/multiformats/go-multiaddr/blob/eef92462702954520ff59a5bab357babd1a55ce5/multiaddr_test.go#L170-L173)
2. [`TestTextMarshaler`](https://github.com/multiformats/go-multiaddr/blob/eef92462702954520ff59a5bab357babd1a55ce5/multiaddr_test.go#L654-L668)