### PR TITLE
CHANGELOG: Prepare v0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.13.0 [unreleased]
+# 0.13.0 [2021-07-08]
 
 - Update to multihash v0.14.0 (see [PR 44]).
 


### PR DESCRIPTION
I would like to cut `multiaddr` crate `v0.13.0`. Among others, this will unblock https://github.com/libp2p/rust-libp2p/pull/2082 and thus pave the way for a new `libp2p` crate release.

Any objections? Anything you would like to see included before the release?