### PR TITLE
src/lib: Add Multiaddr::protocol_stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.rs.bk
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 target
 Cargo.lock
 *.rs.bk
-.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.16.0 [unreleased]
+
+- Create `protocol_stack` for Multiaddr. See [PR 60]
+
 # 0.15.0 [2022-10-20]
 
 - Add `WebRTC` instance for `Multiaddr`. See [PR 59].
@@ -6,8 +10,6 @@
 - Add support for Noise protocol. See [PR 53].
 
 - Use `multibase` instead of `bs58` for base58 encoding. See [PR 56].
-
-- Create `protocol_stack` for Multiaddr. See [PR 60] 
 
 [PR 53]: https://github.com/multiformats/rust-multiaddr/pull/53
 [PR 56]: https://github.com/multiformats/rust-multiaddr/pull/56

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # 0.15.0 [unreleased]
 
+- Add `WebRTC` instance for `Multiaddr`. See [PR 59].
+- Add `Certhash` instance for `Multiaddr`. See [PR 59].
+
 - Add support for Noise protocol. See [PR 53].
 
 - Use `multibase` instead of `bs58` for base58 encoding. See [PR 56].
 
 [PR 53]: https://github.com/multiformats/rust-multiaddr/pull/53
 [PR 56]: https://github.com/multiformats/rust-multiaddr/pull/56
+[PR 59]: https://github.com/multiformats/rust-multiaddr/pull/59
 
 # 0.14.0 [2022-02-02]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - Use `multibase` instead of `bs58` for base58 encoding. See [PR 56].
 
+- Create `protocol_stack` for Multiaddr. See [PR 60] 
+
 [PR 53]: https://github.com/multiformats/rust-multiaddr/pull/53
 [PR 56]: https://github.com/multiformats/rust-multiaddr/pull/56
 [PR 59]: https://github.com/multiformats/rust-multiaddr/pull/59

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["multiaddr", "ipfs"]
 license = "MIT"
 name = "multiaddr"
 readme = "README.md"
-version = "0.15.0"
+version = "0.16.0"
 
 [features]
 default = ["url"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,10 @@ impl Multiaddr {
         }
         self.bytes[(n - m)..] == other.bytes[..]
     }
+
+    pub fn protocol_stack(&self) -> ProtoStackIter {
+        ProtoStackIter{ parts: self.iter() }
+    }
 }
 
 impl fmt::Debug for Multiaddr {
@@ -290,6 +294,17 @@ impl<'a> Iterator for Iter<'a> {
 
         self.0 = next_data;
         Some(p)
+    }
+}
+
+pub struct ProtoStackIter<'a>{
+    parts: Iter<'a>
+}
+
+impl<'a> Iterator for ProtoStackIter<'a> {
+    type Item =  &'static str;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.parts.next().map(|p|p.tag())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ pub struct ProtoStackIter<'a> {
 impl<'a> Iterator for ProtoStackIter<'a> {
     type Item = &'static str;
     fn next(&mut self) -> Option<Self::Item> {
-        self.parts.next().map(|p| p.tag())
+        self.parts.next().as_ref().map(Protocol::tag)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,8 +192,11 @@ impl Multiaddr {
         self.bytes[(n - m)..] == other.bytes[..]
     }
 
+    /// Returns a &str identifiers for the protocols themselves, in order
+    /// This omits specific info like addresses, ports, peer IDs, and the like.
+    /// Example: `"/ip4/127.0.0.1/tcp/5001"` would return `["ip4", "tcp"]`  
     pub fn protocol_stack(&self) -> ProtoStackIter {
-        ProtoStackIter{ parts: self.iter() }
+        ProtoStackIter { parts: self.iter() }
     }
 }
 
@@ -297,14 +300,15 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-pub struct ProtoStackIter<'a>{
-    parts: Iter<'a>
+/// Iterator over the string idtenfiers of the protocols (not addrs) in a multiaddr
+pub struct ProtoStackIter<'a> {
+    parts: Iter<'a>,
 }
 
 impl<'a> Iterator for ProtoStackIter<'a> {
-    type Item =  &'static str;
+    type Item = &'static str;
     fn next(&mut self) -> Option<Self::Item> {
-        self.parts.next().map(|p|p.tag())
+        self.parts.next().map(|p| p.tag())
     }
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -531,7 +531,7 @@ impl<'a> Protocol<'a> {
             Memory(_) => "memory",
             Onion(_, _) => "onion",
             Onion3(_) => "onion3",
-            P2p(_) =>"p2p",
+            P2p(_) => "p2p",
             P2pCircuit => "p2p-circuit",
             Quic => "quic",
             Sctp(_) => "sctp",
@@ -542,9 +542,9 @@ impl<'a> Protocol<'a> {
             Udt => "udt",
             Unix(_) => "unix",
             Utp => "utp",
-            Ws(ref s)  if s == "/" =>  "ws",
+            Ws(ref s) if s == "/" => "ws",
             Ws(_) => "x-parity-ws",
-            Wss(ref s)  if s == "/" =>  "wss",
+            Wss(ref s) if s == "/" => "wss",
             Wss(_) => "x-parity-wss",
         }
     }
@@ -553,61 +553,45 @@ impl<'a> Protocol<'a> {
 impl<'a> fmt::Display for Protocol<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::Protocol::*;
+        write!(f, "/{}", self.tag())?;
         match self {
-            Dccp(port) => write!(f, "/dccp/{}", port),
-            Dns(s) => write!(f, "/dns/{}", s),
-            Dns4(s) => write!(f, "/dns4/{}", s),
-            Dns6(s) => write!(f, "/dns6/{}", s),
-            Dnsaddr(s) => write!(f, "/dnsaddr/{}", s),
-            Http => f.write_str("/http"),
-            Https => f.write_str("/https"),
-            Ip4(addr) => write!(f, "/ip4/{}", addr),
-            Ip6(addr) => write!(f, "/ip6/{}", addr),
-            P2pWebRtcDirect => f.write_str("/p2p-webrtc-direct"),
-            P2pWebRtcStar => f.write_str("/p2p-webrtc-star"),
-            WebRTC => f.write_str("/webrtc"),
+            Dccp(port) => write!(f, "/{}", port),
+            Dns(s) => write!(f, "/{}", s),
+            Dns4(s) => write!(f, "/{}", s),
+            Dns6(s) => write!(f, "/{}", s),
+            Dnsaddr(s) => write!(f, "/{}", s),
+            Ip4(addr) => write!(f, "/{}", addr),
+            Ip6(addr) => write!(f, "/{}", addr),
             Certhash(hash) => write!(
                 f,
-                "/certhash/{}",
+                "{}",
                 multibase::encode(multibase::Base::Base64Url, hash.to_bytes())
             ),
-            P2pWebSocketStar => f.write_str("/p2p-websocket-star"),
-            Memory(port) => write!(f, "/memory/{}", port),
+            Memory(port) => write!(f, "/{}", port),
             Onion(addr, port) => {
                 let s = BASE32.encode(addr.as_ref());
-                write!(f, "/onion/{}:{}", s.to_lowercase(), port)
+                write!(f, "/{}:{}", s.to_lowercase(), port)
             }
             Onion3(addr) => {
                 let s = BASE32.encode(addr.hash());
-                write!(f, "/onion3/{}:{}", s.to_lowercase(), addr.port())
+                write!(f, "/{}:{}", s.to_lowercase(), addr.port())
             }
-            P2p(c) => write!(
-                f,
-                "/p2p/{}",
-                multibase::Base::Base58Btc.encode(c.to_bytes())
-            ),
-            P2pCircuit => f.write_str("/p2p-circuit"),
-            Quic => f.write_str("/quic"),
-            Sctp(port) => write!(f, "/sctp/{}", port),
-            Tcp(port) => write!(f, "/tcp/{}", port),
-            Tls => write!(f, "/tls"),
-            Noise => write!(f, "/noise"),
-            Udp(port) => write!(f, "/udp/{}", port),
-            Udt => f.write_str("/udt"),
-            Unix(s) => write!(f, "/unix/{}", s),
-            Utp => f.write_str("/utp"),
-            Ws(ref s) if s == "/" => f.write_str("/ws"),
-            Ws(s) => {
+            P2p(c) => write!(f, "/{}", multibase::Base::Base58Btc.encode(c.to_bytes())),
+            Sctp(port) => write!(f, "/{}", port),
+            Tcp(port) => write!(f, "/{}", port),
+            Udp(port) => write!(f, "/{}", port),
+            Unix(s) => write!(f, "/{}", s),
+            Ws(s) if s != "/" => {
                 let encoded =
                     percent_encoding::percent_encode(s.as_bytes(), PATH_SEGMENT_ENCODE_SET);
-                write!(f, "/x-parity-ws/{}", encoded)
+                write!(f, "/{}", encoded)
             }
-            Wss(ref s) if s == "/" => f.write_str("/wss"),
-            Wss(s) => {
+            Wss(s) if s != "/" => {
                 let encoded =
                     percent_encoding::percent_encode(s.as_bytes(), PATH_SEGMENT_ENCODE_SET);
-                write!(f, "/x-parity-wss/{}", encoded)
+                write!(f, "/{}", encoded)
             }
+            _ => Ok(()),
         }
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -564,7 +564,7 @@ impl<'a> fmt::Display for Protocol<'a> {
             Ip6(addr) => write!(f, "/{}", addr),
             Certhash(hash) => write!(
                 f,
-                "{}",
+                "/{}",
                 multibase::encode(multibase::Base::Base64Url, hash.to_bytes())
             ),
             Memory(port) => write!(f, "/{}", port),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -510,6 +510,44 @@ impl<'a> Protocol<'a> {
             Wss(cow) => Wss(Cow::Owned(cow.into_owned())),
         }
     }
+
+    pub fn tag(&self) -> &'static str {
+        use self::Protocol::*;
+        match self {
+            Dccp(_) => "dccp",
+            Dns(_) => "dns",
+            Dns4(_) => "dns4",
+            Dns6(_) => "dns6",
+            Dnsaddr(_) => "dnsaddr",
+            Http => "http",
+            Https => "https",
+            Ip4(_) => "ip4",
+            Ip6(_) => "ip6",
+            P2pWebRtcDirect => "p2p-webrtc-direct",
+            P2pWebRtcStar => "p2p-webrtc-star",
+            WebRTC => "webrtc",
+            Certhash(_) => "certhash",
+            P2pWebSocketStar => "p2p-websocket-star",
+            Memory(_) => "memory",
+            Onion(_, _) => "onion",
+            Onion3(_) => "onion3",
+            P2p(_) =>"p2p",
+            P2pCircuit => "p2p-circuit",
+            Quic => "quic",
+            Sctp(_) => "sctp",
+            Tcp(_) => "tcp",
+            Tls => "tls",
+            Noise => "noise",
+            Udp(_) => "udp",
+            Udt => "udt",
+            Unix(_) => "unix",
+            Utp => "utp",
+            Ws(ref s)  if s == "/" =>  "ws",
+            Ws(_) => "x-parity-ws",
+            Wss(ref s)  if s == "/" =>  "wss",
+            Wss(_) => "x-parity-wss",
+        }
+    }
 }
 
 impl<'a> fmt::Display for Protocol<'a> {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -589,7 +589,7 @@ fn protocol_stack() {
     for addr_str in addresses {
         let ma = Multiaddr::from_str(addr_str).expect("These are supposed to be valid multiaddrs");
         let ps: Vec<&str> = ma.protocol_stack().collect();
-        let mut toks: Vec<&str> = addr_str.split("/").collect();
+        let mut toks: Vec<&str> = addr_str.split('/').collect();
         assert_eq!("", toks[0]);
         toks.remove(0);
         let mut i = 0;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -338,6 +338,25 @@ fn construct_success() {
         "047F00000106007FC603",
         vec![Ip4(local), Tcp(127), Noise],
     );
+
+    ma_valid(
+        "/ip4/127.0.0.1/udp/1234/webrtc",
+        "047F000001910204D29802",
+        vec![Ip4(local), Udp(1234), WebRTC],
+    );
+
+    let (_base, decoded) =
+        multibase::decode("uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g").unwrap();
+    ma_valid(
+        "/ip4/127.0.0.1/udp/1234/webrtc/certhash/uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g",
+        "047F000001910204D29802D203221220C3AB8FF13720E8AD9047DD39466B3C8974E592C2FA383D4A3960714CAEF0C4F2",
+        vec![
+            Ip4(local),
+            Udp(1234),
+            WebRTC,
+            Certhash(Multihash::from_bytes(&decoded).unwrap()),
+        ],
+    );
 }
 
 #[test]
@@ -374,6 +393,8 @@ fn construct_fail() {
         "/ip4/127.0.0.1/p2p",
         "/ip4/127.0.0.1/p2p/tcp",
         "/p2p-circuit/50",
+        "/ip4/127.0.0.1/udp/1234/webrtc/certhash",
+        "/ip4/127.0.0.1/udp/1234/webrtc/certhash/b2uaraocy6yrdblb4sfptaddgimjmmp", // 1 character missing from certhash
     ];
 
     for address in &addresses {


### PR DESCRIPTION
A convenience for cases where _which_ protocols is of concern but the specific addresses are not, for example https://github.com/libp2p/rust-libp2p/issues/2758