### PR TITLE
CHANGELOG.md: Prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.15.0 [2022-10-17]
+# 0.15.0 [2022-10-20]
 
 - Add `WebRTC` instance for `Multiaddr`. See [PR 59].
 - Add `Certhash` instance for `Multiaddr`. See [PR 59].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.15.0 [unreleased]
+# 0.15.0 [2022-10-17]
 
 - Add `WebRTC` instance for `Multiaddr`. See [PR 59].
 - Add `Certhash` instance for `Multiaddr`. See [PR 59].


### PR DESCRIPTION
This will allow the Rust WebRTC implementation to move forward. See https://github.com/libp2p/rust-libp2p/pull/2622#discussion_r995583142. //CC @melekes and @thomaseizinger

@dignifiedquire as the official ["Captain"](https://github.com/multiformats/rust-multiaddr#maintainers) of the project, any objections?