### PR TITLE
CHANGELOG: Prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Create `protocol_stack` for Multiaddr. See [PR 60].
 
-- Add `QuicV1` instance for `Multiaddr`. See [PR 64]
+- Add `QuicV1` instance for `Multiaddr`. See [PR 64].
 
 [PR 60]: https://github.com/multiformats/rust-multiaddr/pull/60
 [PR 64]: https://github.com/multiformats/rust-multiaddr/pull/64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# 0.16.0 [unreleased]
+# 0.16.0 [2022-11-04]
 
-- Create `protocol_stack` for Multiaddr. See [PR 60]
+- Create `protocol_stack` for Multiaddr. See [PR 60].
+
+[PR 60]: https://github.com/multiformats/rust-multiaddr/pull/60
 
 # 0.15.0 [2022-10-20]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 - Create `protocol_stack` for Multiaddr. See [PR 60].
 
-[PR 60]: https://github.com/multiformats/rust-multiaddr/pull/60
-
 - Add `QuicV1` instance for `Multiaddr`. See [PR 64]
 
 [PR 60]: https://github.com/multiformats/rust-multiaddr/pull/60


### PR DESCRIPTION
Unlocks https://github.com/libp2p/rust-libp2p/pull/2982.

Any objections by anyone? Anything else you would like to see included?