### PR TITLE
*: Add quic-v1 codepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Create `protocol_stack` for Multiaddr. See [PR 60]
 
+- Add `QuicV1` instance for `Multiaddr`. See [PR 64]
+
+[PR 60]: https://github.com/multiformats/rust-multiaddr/pull/60
+[PR 64]: https://github.com/multiformats/rust-multiaddr/pull/64
+
 # 0.15.0 [2022-10-20]
 
 - Add `WebRTC` instance for `Multiaddr`. See [PR 59].

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ use multiaddr::{Multiaddr, multiaddr};
 
 let address = "/ip4/127.0.0.1/tcp/1234".parse::<Multiaddr>().unwrap();
 // or with a macro
-let other = multiaddr!(Ip4([127, 0, 0, 1]), Udp(10500u16), Quic);
+let other = multiaddr!(Ip4([127, 0, 0, 1]), Udp(10500u16), QuicV1);
 
 assert_eq!(address.to_string(), "/ip4/127.0.0.1/tcp/1234");
-assert_eq!(other.to_string(), "/ip4/127.0.0.1/udp/10500/quic");
+assert_eq!(other.to_string(), "/ip4/127.0.0.1/udp/10500/quic-v1");
 ```
 
 ## Maintainers

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -37,6 +37,7 @@ const ONION3: u32 = 445;
 const P2P: u32 = 421;
 const P2P_CIRCUIT: u32 = 290;
 const QUIC: u32 = 460;
+const QUIC_V1: u32 = 461;
 const SCTP: u32 = 132;
 const TCP: u32 = 6;
 const TLS: u32 = 448;
@@ -92,6 +93,7 @@ pub enum Protocol<'a> {
     P2p(Multihash),
     P2pCircuit,
     Quic,
+    QuicV1,
     Sctp(u16),
     Tcp(u16),
     Tls,
@@ -182,6 +184,7 @@ impl<'a> Protocol<'a> {
                 .and_then(|s| read_onion3(&s.to_uppercase()))
                 .map(|(a, p)| Protocol::Onion3((a, p).into())),
             "quic" => Ok(Protocol::Quic),
+            "quic-v1" => Ok(Protocol::QuicV1),
             "ws" => Ok(Protocol::Ws(Cow::Borrowed("/"))),
             "wss" => Ok(Protocol::Wss(Cow::Borrowed("/"))),
             "x-parity-ws" => {
@@ -314,6 +317,7 @@ impl<'a> Protocol<'a> {
             }
             P2P_CIRCUIT => Ok((Protocol::P2pCircuit, input)),
             QUIC => Ok((Protocol::Quic, input)),
+            QUIC_V1 => Ok((Protocol::QuicV1, input)),
             SCTP => {
                 let (data, rest) = split_at(2, input)?;
                 let mut rdr = Cursor::new(data);
@@ -437,6 +441,7 @@ impl<'a> Protocol<'a> {
                 w.write_u16::<BigEndian>(addr.port())?
             }
             Protocol::Quic => w.write_all(encode::u32(QUIC, &mut buf))?,
+            Protocol::QuicV1 => w.write_all(encode::u32(QUIC_V1, &mut buf))?,
             Protocol::Utp => w.write_all(encode::u32(UTP, &mut buf))?,
             Protocol::Udt => w.write_all(encode::u32(UDT, &mut buf))?,
             Protocol::Http => w.write_all(encode::u32(HTTP, &mut buf))?,
@@ -498,6 +503,7 @@ impl<'a> Protocol<'a> {
             P2p(a) => P2p(a),
             P2pCircuit => P2pCircuit,
             Quic => Quic,
+            QuicV1 => QuicV1,
             Sctp(a) => Sctp(a),
             Tcp(a) => Tcp(a),
             Tls => Tls,
@@ -534,6 +540,7 @@ impl<'a> Protocol<'a> {
             P2p(_) => "p2p",
             P2pCircuit => "p2p-circuit",
             Quic => "quic",
+            QuicV1 => "quic-v1",
             Sctp(_) => "sctp",
             Tcp(_) => "tcp",
             Tls => "tls",

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -89,7 +89,6 @@ impl Arbitrary for Proto {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         use Protocol::*;
         match u8::arbitrary(g) % 27 {
-            // TODO: Add Protocol::Quic
             0 => Proto(Dccp(Arbitrary::arbitrary(g))),
             1 => Proto(Dns(Cow::Owned(SubString::arbitrary(g).0))),
             2 => Proto(Dns4(Cow::Owned(SubString::arbitrary(g).0))),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -88,7 +88,7 @@ struct Proto(Protocol<'static>);
 impl Arbitrary for Proto {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         use Protocol::*;
-        match u8::arbitrary(g) % 26 {
+        match u8::arbitrary(g) % 27 {
             // TODO: Add Protocol::Quic
             0 => Proto(Dccp(Arbitrary::arbitrary(g))),
             1 => Proto(Dns(Cow::Owned(SubString::arbitrary(g).0))),
@@ -133,6 +133,7 @@ impl Arbitrary for Proto {
                 Proto(Onion3((a, std::cmp::max(1, u16::arbitrary(g))).into()))
             }
             25 => Proto(Tls),
+            26 => Proto(QuicV1),
             _ => panic!("outside range"),
         }
     }
@@ -579,6 +580,7 @@ fn protocol_stack() {
         "p2p-webrtc-star",
         "p2p-websocket-star",
         "quic",
+        "quic-v1",
         "tls",
         "udt",
         "utp",


### PR DESCRIPTION
Add `QuicV1` codepoint to represent QUIC Version 1 / RFC 9000. See https://github.com/multiformats/multiaddr/issues/145 for motivation. 

To be merged after https://github.com/multiformats/multicodec/pull/298.