### PR TITLE
tests: add nightly test for Protocol Arbitrary impl to assert it covers all the Protocol variants.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [stable]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -22,13 +21,19 @@ jobs:
           path: ~/.cargo
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install Rust Toolchain
+      - name: Install Rust Stable Toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      - name: Install Rust Nightly Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
 
       - name: Check Code Format
         uses: actions-rs/cargo@v1
@@ -53,6 +58,16 @@ jobs:
         with:
           command: test
           args: --all-features --workspace
+
+      - name: Nightly Test
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: '--cfg nightly -Zcrate-attr=feature(variant_count)'
+        with:
+          toolchain: nightly
+          command: test
+          args: nightly
+
 
   coverage:
     name: Code Coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,6 @@ jobs:
         with:
           toolchain: nightly
           command: test
-          args: nightly
-
 
   coverage:
     name: Code Coverage

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,11 +22,11 @@ impl fmt::Display for Error {
             Error::DataLessThanLen => f.write_str("we have less data than indicated by length"),
             Error::InvalidMultiaddr => f.write_str("invalid multiaddr"),
             Error::InvalidProtocolString => f.write_str("invalid protocol string"),
-            Error::InvalidUvar(e) => write!(f, "failed to decode unsigned varint: {}", e),
-            Error::ParsingError(e) => write!(f, "failed to parse: {}", e),
-            Error::UnknownProtocolId(id) => write!(f, "unknown protocol id: {}", id),
+            Error::InvalidUvar(e) => write!(f, "failed to decode unsigned varint: {e}"),
+            Error::ParsingError(e) => write!(f, "failed to parse: {e}"),
+            Error::UnknownProtocolId(id) => write!(f, "unknown protocol id: {id}"),
             Error::UnknownProtocolString(string) => {
-                write!(f, "unknown protocol string: {}", string)
+                write!(f, "unknown protocol string: {string}")
             }
         }
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -569,19 +569,19 @@ impl<'a> fmt::Display for Protocol<'a> {
         use self::Protocol::*;
         write!(f, "/{}", self.tag())?;
         match self {
-            Dccp(port) => write!(f, "/{}", port),
-            Dns(s) => write!(f, "/{}", s),
-            Dns4(s) => write!(f, "/{}", s),
-            Dns6(s) => write!(f, "/{}", s),
-            Dnsaddr(s) => write!(f, "/{}", s),
-            Ip4(addr) => write!(f, "/{}", addr),
-            Ip6(addr) => write!(f, "/{}", addr),
+            Dccp(port) => write!(f, "/{port}"),
+            Dns(s) => write!(f, "/{s}"),
+            Dns4(s) => write!(f, "/{s}"),
+            Dns6(s) => write!(f, "/{s}"),
+            Dnsaddr(s) => write!(f, "/{s}"),
+            Ip4(addr) => write!(f, "/{addr}"),
+            Ip6(addr) => write!(f, "/{addr}"),
             Certhash(hash) => write!(
                 f,
                 "/{}",
                 multibase::encode(multibase::Base::Base64Url, hash.to_bytes())
             ),
-            Memory(port) => write!(f, "/{}", port),
+            Memory(port) => write!(f, "/{port}"),
             Onion(addr, port) => {
                 let s = BASE32.encode(addr.as_ref());
                 write!(f, "/{}:{}", s.to_lowercase(), port)
@@ -591,19 +591,19 @@ impl<'a> fmt::Display for Protocol<'a> {
                 write!(f, "/{}:{}", s.to_lowercase(), addr.port())
             }
             P2p(c) => write!(f, "/{}", multibase::Base::Base58Btc.encode(c.to_bytes())),
-            Sctp(port) => write!(f, "/{}", port),
-            Tcp(port) => write!(f, "/{}", port),
-            Udp(port) => write!(f, "/{}", port),
-            Unix(s) => write!(f, "/{}", s),
+            Sctp(port) => write!(f, "/{port}"),
+            Tcp(port) => write!(f, "/{port}"),
+            Udp(port) => write!(f, "/{port}"),
+            Unix(s) => write!(f, "/{s}"),
             Ws(s) if s != "/" => {
                 let encoded =
                     percent_encoding::percent_encode(s.as_bytes(), PATH_SEGMENT_ENCODE_SET);
-                write!(f, "/{}", encoded)
+                write!(f, "/{encoded}")
             }
             Wss(s) if s != "/" => {
                 let encoded =
                     percent_encoding::percent_encode(s.as_bytes(), PATH_SEGMENT_ENCODE_SET);
-                write!(f, "/{}", encoded)
+                write!(f, "/{encoded}")
             }
             _ => Ok(()),
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,8 +12,6 @@ use std::{
     str::FromStr,
 };
 
-const IMPL_VARIANT_COUNT: u8 = 32;
-
 // Property tests
 
 #[test]
@@ -87,10 +85,14 @@ impl Arbitrary for Ma {
 #[derive(PartialEq, Eq, Clone, Debug)]
 struct Proto(Protocol<'static>);
 
+impl Proto {
+    const IMPL_VARIANT_COUNT: u8 = 32;
+}
+
 impl Arbitrary for Proto {
     fn arbitrary(g: &mut Gen) -> Self {
         use Protocol::*;
-        match u8::arbitrary(g) % IMPL_VARIANT_COUNT {
+        match u8::arbitrary(g) % Proto::IMPL_VARIANT_COUNT {
             0 => Proto(Dccp(Arbitrary::arbitrary(g))),
             1 => Proto(Dns(Cow::Owned(SubString::arbitrary(g).0))),
             2 => Proto(Dns4(Cow::Owned(SubString::arbitrary(g).0))),
@@ -648,5 +650,5 @@ fn protocol_stack() {
 #[test]
 fn nightly_arbitrary_impl_for_all_proto_variants() {
     let variants = core::mem::variant_count::<Protocol>() as u8;
-    assert_eq!(variants, IMPL_VARIANT_COUNT);
+    assert_eq!(variants, Proto::IMPL_VARIANT_COUNT);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,6 +12,8 @@ use std::{
     str::FromStr,
 };
 
+const IMPL_VARIANT_COUNT: u8 = 32;
+
 // Property tests
 
 #[test]
@@ -88,7 +90,7 @@ struct Proto(Protocol<'static>);
 impl Arbitrary for Proto {
     fn arbitrary(g: &mut Gen) -> Self {
         use Protocol::*;
-        match u8::arbitrary(g) % 32 {
+        match u8::arbitrary(g) % IMPL_VARIANT_COUNT {
             0 => Proto(Dccp(Arbitrary::arbitrary(g))),
             1 => Proto(Dns(Cow::Owned(SubString::arbitrary(g).0))),
             2 => Proto(Dns4(Cow::Owned(SubString::arbitrary(g).0))),
@@ -638,4 +640,13 @@ fn protocol_stack() {
         }
         assert_eq!(ps, toks);
     }
+}
+
+// Assert all `Protocol` variants are covered
+// in its `Arbitrary` impl.
+#[cfg(nightly)]
+#[test]
+fn nightly_arbitrary_impl_for_all_proto_variants() {
+    let variants = core::mem::variant_count::<Protocol>() as u8;
+    assert_eq!(variants, IMPL_VARIANT_COUNT);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -648,7 +648,7 @@ fn protocol_stack() {
 // in its `Arbitrary` impl.
 #[cfg(nightly)]
 #[test]
-fn nightly_arbitrary_impl_for_all_proto_variants() {
+fn arbitrary_impl_for_all_proto_variants() {
     let variants = core::mem::variant_count::<Protocol>() as u8;
     assert_eq!(variants, Proto::IMPL_VARIANT_COUNT);
 }


### PR DESCRIPTION
This PR follows both @mxinden and @thomaseizinger on #65. 
Tried to add multiple toolchains in a single step [but apparently it's not possible](https://github.com/actions-rs/toolchain/issues/215).

Test running [here](https://github.com/multiformats/rust-multiaddr/actions/runs/3743596561/jobs/6355945270#step:10:69)

Closes #65 