### PR TITLE
fix: don't depend on unnecessary `multihash` features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # 0.18.0 [unreleased]
 
 - Add `WebTransport` instance for `Multiaddr`. See [PR 70].
-- Disable all features of `multihash`. See [PR XX].
+- Disable all features of `multihash`. See [PR 77].
 
 [PR 70]: https://github.com/multiformats/rust-multiaddr/pull/70
-[PR XX]: https://github.com/multiformats/rust-multiaddr/pull/XX
+[PR 77]: https://github.com/multiformats/rust-multiaddr/pull/77
 
 # 0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # 0.18.0 [unreleased]
 
 - Add `WebTransport` instance for `Multiaddr`. See [PR 70].
+- Disable all features of `multihash`. See [PR XX].
 
 [PR 70]: https://github.com/multiformats/rust-multiaddr/pull/70
+[PR XX]: https://github.com/multiformats/rust-multiaddr/pull/XX
 
 # 0.17.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ arrayref = "0.3"
 byteorder = "1.3.1"
 data-encoding = "2.1"
 multibase = "0.9.1"
-multihash = { version = "0.18", default-features = false, features = ["std", "multihash-impl", "identity"] }
+multihash = { version = "0.18", default-features = false, features = ["std"] }
 percent-encoding = "2.1.0"
 serde = "1.0.70"
 static_assertions = "1.1"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -52,6 +52,11 @@ const WS_WITH_PATH: u32 = 4770; // Note: not standard
 const WSS: u32 = 478;
 const WSS_WITH_PATH: u32 = 4780; // Note: not standard
 
+/// Type-alias for how multi-addresses use `Multihash`.
+///
+/// The `64` defines the allocation size for the digest within the `Multihash`.
+/// This allows us to use hashes such as SHA512.
+/// In case protocols like `/certhash` ever support hashes larger than that, we will need to update this size here (which will be a breaking change!).
 type Multihash = MultihashGeneric<64>;
 
 const PATH_SEGMENT_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@ use crate::{Error, Result};
 use arrayref::array_ref;
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt, WriteBytesExt};
 use data_encoding::BASE32;
-use multihash::Multihash;
+use multihash::MultihashGeneric;
 use std::{
     borrow::Cow,
     convert::From,
@@ -51,6 +51,8 @@ const WS: u32 = 477;
 const WS_WITH_PATH: u32 = 4770; // Note: not standard
 const WSS: u32 = 478;
 const WSS_WITH_PATH: u32 = 4780; // Note: not standard
+
+type Multihash = MultihashGeneric<64>;
 
 const PATH_SEGMENT_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
     .add(b'%')

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 use data_encoding::HEXUPPER;
 use multiaddr::*;
 use multihash::MultihashGeneric;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,7 +2,7 @@ extern crate core;
 
 use data_encoding::HEXUPPER;
 use multiaddr::*;
-use multihash::{Code, Multihash};
+use multihash::MultihashGeneric;
 use quickcheck::{Arbitrary, Gen, QuickCheck};
 use std::{
     borrow::Cow,
@@ -145,14 +145,13 @@ impl Arbitrary for Proto {
 }
 
 #[derive(Clone, Debug)]
-struct Mh(Multihash);
+struct Mh(MultihashGeneric<64>);
 
 impl Arbitrary for Mh {
     fn arbitrary(g: &mut Gen) -> Self {
         let mut hash: [u8; 32] = [0; 32];
         hash.fill_with(|| u8::arbitrary(g));
-        Mh(Multihash::wrap(Code::Identity.into(), &hash)
-            .expect("The digest size is never too large"))
+        Mh(MultihashGeneric::wrap(0x0, &hash).expect("The digest size is never too large"))
     }
 }
 
@@ -180,8 +179,8 @@ fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol<'_>>) {
     );
 }
 
-fn multihash(s: &str) -> Multihash {
-    Multihash::from_bytes(&multibase::Base::Base58Btc.decode(s).unwrap()).unwrap()
+fn multihash(s: &str) -> MultihashGeneric<64> {
+    MultihashGeneric::from_bytes(&multibase::Base::Base58Btc.decode(s).unwrap()).unwrap()
 }
 
 #[test]
@@ -374,7 +373,7 @@ fn construct_success() {
             Ip4(local),
             Udp(1234),
             WebRTC,
-            Certhash(Multihash::from_bytes(&decoded).unwrap()),
+            Certhash(MultihashGeneric::from_bytes(&decoded).unwrap()),
         ],
     );
 
@@ -393,7 +392,7 @@ fn construct_success() {
             Ip4(local),
             Udp(1234),
             WebTransport,
-            Certhash(Multihash::from_bytes(&decoded).unwrap()),
+            Certhash(MultihashGeneric::from_bytes(&decoded).unwrap()),
         ],
     );
 }


### PR DESCRIPTION
With these features activated, `multihash` is quite heavy. Whilst we are in the process of fixing this, removing these features is a first good step towards that.

I think technically, this is a breaking change unfortunately because we re-export all of `multihash` and thus someone could have relied on the presence of `multihash::Code` through the re-export of `multihash`.