### PR TITLE
fix: Rename `Protocol::WebRTC` to `Protocol::WebRTCDirect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Disable all features of `multihash`. See [PR 77].
 - Mark `Protocol` as `#[non_exhaustive]`. See [PR 82].
 
-- Rename `Protocol::WebRTC` to `Protocol::WebRTC`.
+- Rename `Protocol::WebRTC` to `Protocol::WebRTCDirect`.
   See [multiformats/multiaddr discussion] for context.
   Remove deprecated support for `/webrtc` in favor of the existing `/webrtc-direct` string representation.
   **Note that this is a breaking change.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-# 0.18.0 [unreleased]
+# 0.18.0 - unreleased
 
 - Add `WebTransport` instance for `Multiaddr`. See [PR 70].
 
+- Rename `/webrtc` to `/webrt-direct`. See [multiformats/multiaddr discussion] for context. **Note that this is a breaking change.**
+
+[multiformats/multiaddr discussion]: https://github.com/multiformats/multiaddr/pull/150#issuecomment-1468791586
 [PR 70]: https://github.com/multiformats/rust-multiaddr/pull/70
 
 # 0.17.0

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -28,7 +28,7 @@ const IP4: u32 = 4;
 const IP6: u32 = 41;
 const P2P_WEBRTC_DIRECT: u32 = 276;
 const P2P_WEBRTC_STAR: u32 = 275;
-const WEBRTC: u32 = 280;
+const WEBRTC_DIRECT: u32 = 280;
 const CERTHASH: u32 = 466;
 const P2P_WEBSOCKET_STAR: u32 = 479;
 const MEMORY: u32 = 777;
@@ -84,7 +84,7 @@ pub enum Protocol<'a> {
     Ip6(Ipv6Addr),
     P2pWebRtcDirect,
     P2pWebRtcStar,
-    WebRTC,
+    WebRTCDirect,
     Certhash(Multihash),
     P2pWebSocketStar,
     /// Contains the "port" to contact. Similar to TCP or UDP, 0 means "assign me a port".
@@ -202,7 +202,7 @@ impl<'a> Protocol<'a> {
             }
             "p2p-websocket-star" => Ok(Protocol::P2pWebSocketStar),
             "p2p-webrtc-star" => Ok(Protocol::P2pWebRtcStar),
-            "webrtc" => Ok(Protocol::WebRTC),
+            "webrtc-direct" => Ok(Protocol::WebRTCDirect),
             "certhash" => {
                 let s = iter.next().ok_or(Error::InvalidProtocolString)?;
                 let (_base, decoded) = multibase::decode(s)?;
@@ -284,7 +284,7 @@ impl<'a> Protocol<'a> {
             }
             P2P_WEBRTC_DIRECT => Ok((Protocol::P2pWebRtcDirect, input)),
             P2P_WEBRTC_STAR => Ok((Protocol::P2pWebRtcStar, input)),
-            WEBRTC => Ok((Protocol::WebRTC, input)),
+            WEBRTC_DIRECT => Ok((Protocol::WebRTCDirect, input)),
             CERTHASH => {
                 let (n, input) = decode::usize(input)?;
                 let (data, rest) = split_at(n, input)?;
@@ -467,7 +467,7 @@ impl<'a> Protocol<'a> {
             }
             Protocol::P2pWebSocketStar => w.write_all(encode::u32(P2P_WEBSOCKET_STAR, &mut buf))?,
             Protocol::P2pWebRtcStar => w.write_all(encode::u32(P2P_WEBRTC_STAR, &mut buf))?,
-            Protocol::WebRTC => w.write_all(encode::u32(WEBRTC, &mut buf))?,
+            Protocol::WebRTCDirect => w.write_all(encode::u32(WEBRTC_DIRECT, &mut buf))?,
             Protocol::Certhash(hash) => {
                 w.write_all(encode::u32(CERTHASH, &mut buf))?;
                 let bytes = hash.to_bytes();
@@ -499,7 +499,7 @@ impl<'a> Protocol<'a> {
             Ip6(a) => Ip6(a),
             P2pWebRtcDirect => P2pWebRtcDirect,
             P2pWebRtcStar => P2pWebRtcStar,
-            WebRTC => WebRTC,
+            WebRTCDirect => WebRTCDirect,
             Certhash(hash) => Certhash(hash),
             P2pWebSocketStar => P2pWebSocketStar,
             Memory(a) => Memory(a),
@@ -537,7 +537,7 @@ impl<'a> Protocol<'a> {
             Ip6(_) => "ip6",
             P2pWebRtcDirect => "p2p-webrtc-direct",
             P2pWebRtcStar => "p2p-webrtc-star",
-            WebRTC => "webrtc",
+            WebRTCDirect => "webrtc-direct",
             Certhash(_) => "certhash",
             P2pWebSocketStar => "p2p-websocket-star",
             Memory(_) => "memory",

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -104,7 +104,7 @@ impl Arbitrary for Proto {
             8 => Proto(Ip6(Ipv6Addr::arbitrary(g))),
             9 => Proto(P2pWebRtcDirect),
             10 => Proto(P2pWebRtcStar),
-            11 => Proto(WebRTC),
+            11 => Proto(WebRTCDirect),
             12 => Proto(Certhash(Mh::arbitrary(g).0)),
             13 => Proto(P2pWebSocketStar),
             14 => Proto(Memory(Arbitrary::arbitrary(g))),
@@ -360,20 +360,20 @@ fn construct_success() {
     );
 
     ma_valid(
-        "/ip4/127.0.0.1/udp/1234/webrtc",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct",
         "047F000001910204D29802",
-        vec![Ip4(local), Udp(1234), WebRTC],
+        vec![Ip4(local), Udp(1234), WebRTCDirect],
     );
 
     let (_base, decoded) =
         multibase::decode("uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g").unwrap();
     ma_valid(
-        "/ip4/127.0.0.1/udp/1234/webrtc/certhash/uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct/certhash/uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g",
         "047F000001910204D29802D203221220C3AB8FF13720E8AD9047DD39466B3C8974E592C2FA383D4A3960714CAEF0C4F2",
         vec![
             Ip4(local),
             Udp(1234),
-            WebRTC,
+            WebRTCDirect,
             Certhash(Multihash::from_bytes(&decoded).unwrap()),
         ],
     );
@@ -432,8 +432,8 @@ fn construct_fail() {
         "/ip4/127.0.0.1/p2p",
         "/ip4/127.0.0.1/p2p/tcp",
         "/p2p-circuit/50",
-        "/ip4/127.0.0.1/udp/1234/webrtc/certhash",
-        "/ip4/127.0.0.1/udp/1234/webrtc/certhash/b2uaraocy6yrdblb4sfptaddgimjmmp", // 1 character missing from certhash
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct/certhash",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct/certhash/b2uaraocy6yrdblb4sfptaddgimjmmp", // 1 character missing from certhash
     ];
 
     for address in &addresses {
@@ -605,7 +605,7 @@ fn protocol_stack() {
         "/ip4/127.0.0.1/tcp/127/tls",
         "/ip4/127.0.0.1/tcp/127/tls/ws",
         "/ip4/127.0.0.1/tcp/127/noise",
-        "/ip4/127.0.0.1/udp/1234/webrtc",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct",
     ];
     let argless = std::collections::HashSet::from([
         "http",
@@ -620,7 +620,7 @@ fn protocol_stack() {
         "tls",
         "udt",
         "utp",
-        "webrtc",
+        "webrtc-direct",
         "ws",
         "wss",
     ]);


### PR DESCRIPTION
See https://github.com/multiformats/multiaddr/pull/150#issuecomment-1468791586 for context.

@melekes @thomaseizinger can you give this a review?