### PR TITLE
feat!: mark `Protocol` as `non_exhaustive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add `WebTransport` instance for `Multiaddr`. See [PR 70].
 - Disable all features of `multihash`. See [PR 77].
-- Mark `Protocol` as `#[non_exhaustive]`. See [PR 82.]
+- Mark `Protocol` as `#[non_exhaustive]`. See [PR 82].
 
 [PR 70]: https://github.com/multiformats/rust-multiaddr/pull/70
 [PR 77]: https://github.com/multiformats/rust-multiaddr/pull/77

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 - Add `WebTransport` instance for `Multiaddr`. See [PR 70].
 - Disable all features of `multihash`. See [PR 77].
+- Mark `Protocol` as `#[non_exhaustive]`. See [PR 82.]
 
 [PR 70]: https://github.com/multiformats/rust-multiaddr/pull/70
 [PR 77]: https://github.com/multiformats/rust-multiaddr/pull/77
+[PR 82]: https://github.com/multiformats/rust-multiaddr/pull/82
 
 # 0.17.0
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -79,6 +79,7 @@ const PATH_SEGMENT_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::
 /// platform-specific. This means that the actual validation of paths needs to
 /// happen separately.
 #[derive(PartialEq, Eq, Clone, Debug)]
+#[non_exhaustive]
 pub enum Protocol<'a> {
     Dccp(u16),
     Dns(Cow<'a, str>),


### PR DESCRIPTION
As an effort towards #71, mark `Protocol` as `non_exhaustive`. This allows us to add new variants without breaking downstream code.

I think matching on the `Protocol` is important, thus I chose to use `non_exhaustive` here over making it opaque.