### PR TITLE
fix: Rename `Protocol::WebRTC` string rep `/webrtc` to `/webrtc-direct`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.17.1
+
+- Rename string representation of `WebRTC` protocol from `/webrtc` to `/webrt-direct`.
+  For backwards compatibility `/webrtc` will still be decoded to `Protocol::WebRTC`, but `Protocol::WebRTC` will from now on always be encoded as `/webrtc-direct`.
+  See [multiformats/multiaddr discussion] for context.
+  ``` rust
+  assert_eq!(
+      Multiaddr::empty().with(Protocol::WebRTC),
+      "/webrtc".parse().unwrap(),
+  );
+  assert_eq!(
+      Multiaddr::empty().with(Protocol::WebRTC),
+      "/webrtc-direct".parse().unwrap(),
+  );
+  assert_eq!(
+      "/webrtc-direct",
+      Multiaddr::empty().with(Protocol::WebRTC).to_string(),
+  );
+  assert_ne!(
+      "/webrtc",
+      Multiaddr::empty().with(Protocol::WebRTC).to_string(),
+  );
+  ```
+
 # 0.17.0
 
 - Update to multihash `v0.17`. See [PR 63].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Rename string representation of `WebRTC` protocol from `/webrtc` to `/webrt-direct`.
   For backwards compatibility `/webrtc` will still be decoded to `Protocol::WebRTC`, but `Protocol::WebRTC` will from now on always be encoded as `/webrtc-direct`.
-  See [multiformats/multiaddr discussion] for context.
+  See [multiformats/multiaddr discussion] and [PR 84] for context.
   ``` rust
   assert_eq!(
       Multiaddr::empty().with(Protocol::WebRTC),
@@ -21,6 +21,8 @@
       Multiaddr::empty().with(Protocol::WebRTC).to_string(),
   );
   ```
+
+[PR 84]: https://github.com/multiformats/rust-multiaddr/pull/84
 
 # 0.17.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default = ["url"]
 arrayref = "0.3"
 byteorder = "1.3.1"
 data-encoding = "2.1"
+log = "0.4"
 multibase = "0.9.1"
 multihash = { version = "0.17", default-features = false, features = ["std", "multihash-impl", "identity"] }
 percent-encoding = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["multiaddr", "ipfs"]
 license = "MIT"
 name = "multiaddr"
 readme = "README.md"
-version = "0.17.0"
+version = "0.17.1"
 
 [features]
 default = ["url"]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -199,7 +199,10 @@ impl<'a> Protocol<'a> {
             }
             "p2p-websocket-star" => Ok(Protocol::P2pWebSocketStar),
             "p2p-webrtc-star" => Ok(Protocol::P2pWebRtcStar),
-            "webrtc" => Ok(Protocol::WebRTC),
+            "webrtc" => {
+                log::warn!("Parsed deprecated /webrtc. Use /webrtc-direct instead.");
+                Ok(Protocol::WebRTC)
+            }
             "webrtc-direct" => Ok(Protocol::WebRTC),
             "certhash" => {
                 let s = iter.next().ok_or(Error::InvalidProtocolString)?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -200,6 +200,7 @@ impl<'a> Protocol<'a> {
             "p2p-websocket-star" => Ok(Protocol::P2pWebSocketStar),
             "p2p-webrtc-star" => Ok(Protocol::P2pWebRtcStar),
             "webrtc" => Ok(Protocol::WebRTC),
+            "webrtc-direct" => Ok(Protocol::WebRTC),
             "certhash" => {
                 let s = iter.next().ok_or(Error::InvalidProtocolString)?;
                 let (_base, decoded) = multibase::decode(s)?;
@@ -531,7 +532,7 @@ impl<'a> Protocol<'a> {
             Ip6(_) => "ip6",
             P2pWebRtcDirect => "p2p-webrtc-direct",
             P2pWebRtcStar => "p2p-webrtc-star",
-            WebRTC => "webrtc",
+            WebRTC => "webrtc-direct",
             Certhash(_) => "certhash",
             P2pWebSocketStar => "p2p-websocket-star",
             Memory(_) => "memory",

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -342,7 +342,7 @@ fn construct_success() {
     );
 
     ma_valid(
-        "/ip4/127.0.0.1/udp/1234/webrtc",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct",
         "047F000001910204D29802",
         vec![Ip4(local), Udp(1234), WebRTC],
     );
@@ -350,7 +350,7 @@ fn construct_success() {
     let (_base, decoded) =
         multibase::decode("uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g").unwrap();
     ma_valid(
-        "/ip4/127.0.0.1/udp/1234/webrtc/certhash/uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct/certhash/uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g",
         "047F000001910204D29802D203221220C3AB8FF13720E8AD9047DD39466B3C8974E592C2FA383D4A3960714CAEF0C4F2",
         vec![
             Ip4(local),
@@ -395,8 +395,8 @@ fn construct_fail() {
         "/ip4/127.0.0.1/p2p",
         "/ip4/127.0.0.1/p2p/tcp",
         "/p2p-circuit/50",
-        "/ip4/127.0.0.1/udp/1234/webrtc/certhash",
-        "/ip4/127.0.0.1/udp/1234/webrtc/certhash/b2uaraocy6yrdblb4sfptaddgimjmmp", // 1 character missing from certhash
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct/certhash",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct/certhash/b2uaraocy6yrdblb4sfptaddgimjmmp", // 1 character missing from certhash
     ];
 
     for address in &addresses {
@@ -568,7 +568,7 @@ fn protocol_stack() {
         "/ip4/127.0.0.1/tcp/127/tls",
         "/ip4/127.0.0.1/tcp/127/tls/ws",
         "/ip4/127.0.0.1/tcp/127/noise",
-        "/ip4/127.0.0.1/udp/1234/webrtc",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct",
     ];
     let argless = std::collections::HashSet::from([
         "http",
@@ -583,7 +583,7 @@ fn protocol_stack() {
         "tls",
         "udt",
         "utp",
-        "webrtc",
+        "webrtc-direct",
         "ws",
         "wss",
     ]);
@@ -605,4 +605,24 @@ fn protocol_stack() {
         }
         assert_eq!(ps, toks);
     }
+}
+
+#[test]
+fn webrtc_webrtc_direct_rename() {
+    assert_eq!(
+        Multiaddr::empty().with(Protocol::WebRTC),
+        "/webrtc".parse().unwrap(),
+    );
+    assert_eq!(
+        Multiaddr::empty().with(Protocol::WebRTC),
+        "/webrtc-direct".parse().unwrap(),
+    );
+    assert_eq!(
+        "/webrtc-direct",
+        Multiaddr::empty().with(Protocol::WebRTC).to_string(),
+    );
+    assert_ne!(
+        "/webrtc",
+        Multiaddr::empty().with(Protocol::WebRTC).to_string(),
+    );
 }


### PR DESCRIPTION
Considered non-breaking change as `/webrtc` will still be parsed to `Protocol::WebRTC` and no known production deployment of `libp2p-webrtc` known.

See https://github.com/multiformats/multiaddr/pull/150#issuecomment-1468791586 for context.

@melekes @thomaseizinger can you take a look?

