### PR TITLE
fix: Rename `Protocol::WebRTC` string rep `/webrtc` to `/webrtc-direct`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@
 [PR 77]: https://github.com/multiformats/rust-multiaddr/pull/77
 [PR 82]: https://github.com/multiformats/rust-multiaddr/pull/82
 
+# 0.17.1
+
+- Rename string representation of `WebRTC` protocol from `/webrtc` to `/webrt-direct`.
+  For backwards compatibility `/webrtc` will still be decoded to `Protocol::WebRTC`, but `Protocol::WebRTC` will from now on always be encoded as `/webrtc-direct`.
+  See [multiformats/multiaddr discussion] and [PR 84] for context.
+  ``` rust
+  assert_eq!(
+      Multiaddr::empty().with(Protocol::WebRTC),
+      "/webrtc".parse().unwrap(),
+  );
+  assert_eq!(
+      Multiaddr::empty().with(Protocol::WebRTC),
+      "/webrtc-direct".parse().unwrap(),
+  );
+  assert_eq!(
+      "/webrtc-direct",
+      Multiaddr::empty().with(Protocol::WebRTC).to_string(),
+  );
+  assert_ne!(
+      "/webrtc",
+      Multiaddr::empty().with(Protocol::WebRTC).to_string(),
+  );
+  ```
+
+[PR 84]: https://github.com/multiformats/rust-multiaddr/pull/84
+
 # 0.17.0
 
 - Update to multihash `v0.17`. See [PR 63].

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default = ["url"]
 arrayref = "0.3"
 byteorder = "1.3.1"
 data-encoding = "2.1"
+log = "0.4"
 multibase = "0.9.1"
 multihash = { version = "0.18", default-features = false, features = ["std"] }
 percent-encoding = "2.1.0"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -210,7 +210,11 @@ impl<'a> Protocol<'a> {
             }
             "p2p-websocket-star" => Ok(Protocol::P2pWebSocketStar),
             "p2p-webrtc-star" => Ok(Protocol::P2pWebRtcStar),
-            "webrtc" => Ok(Protocol::WebRTC),
+            "webrtc" => {
+                log::warn!("Parsed deprecated /webrtc. Use /webrtc-direct instead.");
+                Ok(Protocol::WebRTC)
+            }
+            "webrtc-direct" => Ok(Protocol::WebRTC),
             "certhash" => {
                 let s = iter.next().ok_or(Error::InvalidProtocolString)?;
                 let (_base, decoded) = multibase::decode(s)?;
@@ -545,7 +549,7 @@ impl<'a> Protocol<'a> {
             Ip6(_) => "ip6",
             P2pWebRtcDirect => "p2p-webrtc-direct",
             P2pWebRtcStar => "p2p-webrtc-star",
-            WebRTC => "webrtc",
+            WebRTC => "webrtc-direct",
             Certhash(_) => "certhash",
             P2pWebSocketStar => "p2p-websocket-star",
             Memory(_) => "memory",

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -357,7 +357,7 @@ fn construct_success() {
     );
 
     ma_valid(
-        "/ip4/127.0.0.1/udp/1234/webrtc",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct",
         "047F000001910204D29802",
         vec![Ip4(local), Udp(1234), WebRTC],
     );
@@ -365,7 +365,7 @@ fn construct_success() {
     let (_base, decoded) =
         multibase::decode("uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g").unwrap();
     ma_valid(
-        "/ip4/127.0.0.1/udp/1234/webrtc/certhash/uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct/certhash/uEiDDq4_xNyDorZBH3TlGazyJdOWSwvo4PUo5YHFMrvDE8g",
         "047F000001910204D29802D203221220C3AB8FF13720E8AD9047DD39466B3C8974E592C2FA383D4A3960714CAEF0C4F2",
         vec![
             Ip4(local),
@@ -429,8 +429,8 @@ fn construct_fail() {
         "/ip4/127.0.0.1/p2p",
         "/ip4/127.0.0.1/p2p/tcp",
         "/p2p-circuit/50",
-        "/ip4/127.0.0.1/udp/1234/webrtc/certhash",
-        "/ip4/127.0.0.1/udp/1234/webrtc/certhash/b2uaraocy6yrdblb4sfptaddgimjmmp", // 1 character missing from certhash
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct/certhash",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct/certhash/b2uaraocy6yrdblb4sfptaddgimjmmp", // 1 character missing from certhash
     ];
 
     for address in &addresses {
@@ -602,7 +602,7 @@ fn protocol_stack() {
         "/ip4/127.0.0.1/tcp/127/tls",
         "/ip4/127.0.0.1/tcp/127/tls/ws",
         "/ip4/127.0.0.1/tcp/127/noise",
-        "/ip4/127.0.0.1/udp/1234/webrtc",
+        "/ip4/127.0.0.1/udp/1234/webrtc-direct",
     ];
     let argless = std::collections::HashSet::from([
         "http",
@@ -617,7 +617,7 @@ fn protocol_stack() {
         "tls",
         "udt",
         "utp",
-        "webrtc",
+        "webrtc-direct",
         "ws",
         "wss",
     ]);
@@ -648,4 +648,24 @@ fn protocol_stack() {
 fn arbitrary_impl_for_all_proto_variants() {
     let variants = core::mem::variant_count::<Protocol>() as u8;
     assert_eq!(variants, Proto::IMPL_VARIANT_COUNT);
+}
+
+#[test]
+fn webrtc_webrtc_direct_rename() {
+    assert_eq!(
+        Multiaddr::empty().with(Protocol::WebRTC),
+        "/webrtc".parse().unwrap(),
+    );
+    assert_eq!(
+        Multiaddr::empty().with(Protocol::WebRTC),
+        "/webrtc-direct".parse().unwrap(),
+    );
+    assert_eq!(
+        "/webrtc-direct",
+        Multiaddr::empty().with(Protocol::WebRTC).to_string(),
+    );
+    assert_ne!(
+        "/webrtc",
+        Multiaddr::empty().with(Protocol::WebRTC).to_string(),
+    );
 }


### PR DESCRIPTION
Considered non-breaking change as `/webrtc` will still be parsed to `Protocol::WebRTC` and no known production deployment of `libp2p-webrtc` known.

See https://github.com/multiformats/multiaddr/pull/150#issuecomment-1468791586 for context.

Forward-port of https://github.com/multiformats/rust-multiaddr/pull/84 to `master`.