### PR TITLE
Changed multiaddr backing from Arc<Vec<u8>> to EcoVec<u8>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default = ["url"]
 arrayref = "0.3"
 byteorder = "1.3.1"
 data-encoding = "2.1"
+ecow = { version = "0.1.1", features = ["serde"] }
 multibase = "0.9.1"
 multihash = { version = "0.18", default-features = false, features = ["std"] }
 percent-encoding = "2.1.0"


### PR DESCRIPTION
While this increases the size of a multiaddr on the stack or in a container (from 1 word to 2 words), it decreases the overall memory usage of the multiaddr (from 2 allocations to 1 allocation) and avoids a double dereference when manipulating multiaddrs. Hence, I believe that this should be a win for most applications.

This PR currently includes a hack so that `EcoVec<u8>` implements `Write`, but if https://github.com/typst/ecow/pull/23 lands, it can be removed. 