### PR TITLE
Add conversions between sockets and multiaddrs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
     convert::TryFrom,
     fmt, io,
     iter::FromIterator,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     result::Result as StdResult,
     str::FromStr,
     sync::Arc,
@@ -475,6 +475,19 @@ macro_rules! multiaddr {
                 };
             )+
             elem.collect::<$crate::Multiaddr>()
+        }
+    }
+}
+
+impl From<SocketAddr> for Multiaddr {
+    fn from(socket: SocketAddr) -> Self {
+        match socket {
+            SocketAddr::V4(sock) => Self::empty()
+                .with(Protocol::Ip4(*sock.ip()))
+                .with(Protocol::Tcp(sock.port())),
+            SocketAddr::V6(sock) => Self::empty()
+                .with(Protocol::Ip6(*sock.ip()))
+                .with(Protocol::Tcp(sock.port())),
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,7 +7,7 @@ use std::{
     borrow::Cow,
     convert::{TryFrom, TryInto},
     iter::{self, FromIterator},
-    net::{Ipv4Addr, Ipv6Addr},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     str::FromStr,
 };
 
@@ -660,4 +660,34 @@ fn protocol_stack() {
 fn arbitrary_impl_for_all_proto_variants() {
     let variants = core::mem::variant_count::<Protocol>() as u8;
     assert_eq!(variants, Proto::IMPL_VARIANT_COUNT);
+}
+
+#[test]
+fn from_ipv4_socket() {
+    let socket_addr: SocketAddr =
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80));
+    let expected_multiaddr: Multiaddr = Multiaddr::empty()
+        .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
+        .with(Protocol::Tcp(80));
+
+    let actual_multiaddr: Multiaddr = socket_addr.into();
+
+    assert_eq!(actual_multiaddr, expected_multiaddr);
+}
+
+#[test]
+fn from_ipv6_socket() {
+    let socket_addr: SocketAddr = SocketAddr::V6(SocketAddrV6::new(
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+        80,
+        0,
+        0,
+    ));
+    let expected_multiaddr: Multiaddr = Multiaddr::empty()
+        .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
+        .with(Protocol::Tcp(80));
+
+    let actual_multiaddr: Multiaddr = socket_addr.into();
+
+    assert_eq!(actual_multiaddr, expected_multiaddr);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -691,3 +691,35 @@ fn from_ipv6_socket() {
 
     assert_eq!(actual_multiaddr, expected_multiaddr);
 }
+
+#[test]
+fn into_ipv4_socket() {
+    let multiaddr: Multiaddr = Multiaddr::empty()
+        .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
+        .with(Protocol::Tcp(80));
+    let expected_socket_addr: SocketAddr =
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80));
+
+    let actual_socket_addr: Result<SocketAddr> = multiaddr.try_into();
+
+    assert!(actual_socket_addr.is_ok());
+    assert_eq!(actual_socket_addr.unwrap(), expected_socket_addr);
+}
+
+#[test]
+fn into_ipv6_socket() {
+    let multiaddr: Multiaddr = Multiaddr::empty()
+        .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
+        .with(Protocol::Tcp(80));
+    let expected_socket_addr: SocketAddr = SocketAddr::V6(SocketAddrV6::new(
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+        80,
+        0,
+        0,
+    ));
+
+    let actual_socket_addr: Result<SocketAddr> = multiaddr.try_into();
+
+    assert!(actual_socket_addr.is_ok());
+    assert_eq!(actual_socket_addr.unwrap(), expected_socket_addr);
+}


### PR DESCRIPTION
This PR allows two type conversions involving both `Multiaddr` and `SocketAddr`:

 - An infallible conversion from `SocketAddr` to `Multiaddr`
 - A fallible conversion from `Multiaddr` to `SocketAddr` (as the space of all possible values of the former is obviously much larger than that for the latter)

These are certainly fairly minor changes; however, they enable some niceties such as:

```rust
match libp2p_event {
    FromSwarm::NewListenAddr { listener_id: _, addr: Multiaddr } => if let Ok(sock) = addr.try_into::<SocketAddr>() {
        do_something_with_socket(sock);
    } else {
        panic!("Something went wrong!");
    }
}
```