### PR TITLE
feat: add with_p2p method on multiaddr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.18.1 - unreleased
+
+- Add `to_p2p_terminated` on `Multiaddr`. See [PR 102].
+
+[PR 102]: https://github.com/multiformats/rust-multiaddr/pull/102
+
 # 0.18.0
 
 - Add `WebTransport` instance for `Multiaddr`. See [PR 70].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.18.1 - unreleased
 
-- Add `to_p2p_terminated` on `Multiaddr`. See [PR 102].
+- Add `with_p2p` and `from_str_and_peer` on `Multiaddr`. See [PR 102].
 
 [PR 102]: https://github.com/multiformats/rust-multiaddr/pull/102
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.18.1 - unreleased
 
-- Add `with_p2p` and `from_str_and_peer` on `Multiaddr`. See [PR 102].
+- Add `with_p2p` on `Multiaddr`. See [PR 102].
 
 [PR 102]: https://github.com/multiformats/rust-multiaddr/pull/102
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,15 +129,6 @@ impl Multiaddr {
         self
     }
 
-    /// Parses a [`Multiaddr`] from the given string, ensuring that it ends with [`Protocol::P2p`] of the provided peer.
-    ///
-    /// If the address does not end with `/p2p`, it is simply appended.
-    /// If the address ends with a _different_ peer ID, parsing will fail.
-    pub fn from_str_and_peer(addr: &str, peer: PeerId) -> Result<Self> {
-        let addr = addr.parse::<Self>()?;
-        addr.with_p2p(peer).map_err(|_| Error::InvalidMultiaddr)
-    }
-
     /// Appends the given [`PeerId`] if not yet present at the end of this multiaddress.
     ///
     /// Fails if this address ends in a _different_ [`PeerId`].

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -661,3 +661,36 @@ fn arbitrary_impl_for_all_proto_variants() {
     let variants = core::mem::variant_count::<Protocol>() as u8;
     assert_eq!(variants, Proto::IMPL_VARIANT_COUNT);
 }
+
+#[test]
+fn to_p2p_terminated() {
+    let peer_id = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+        .parse::<PeerId>()
+        .unwrap();
+
+    const TEST_DATA: &[(&str, &str)] = &[
+        (
+            "/ip4/127.0.0.1",
+            "/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+        ),
+        (
+            "/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+            "/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+        ),
+        (
+            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+        ),
+        (
+            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+        ),
+    ];
+
+    for (input, expected) in TEST_DATA {
+        let input = input.parse::<Multiaddr>().unwrap();
+        let expected = expected.parse::<Multiaddr>().unwrap();
+
+        assert_eq!(expected, input.to_p2p_terminated(peer_id));
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -662,49 +662,65 @@ fn arbitrary_impl_for_all_proto_variants() {
     assert_eq!(variants, Proto::IMPL_VARIANT_COUNT);
 }
 
-#[test]
-fn multiaddr_with_p2p_and_from_str_and_peer() {
-    const TEST_DATA: &[(&str, &str, std::result::Result<&str, &str>)] = &[
-        (
-            // Multiaddr is empty -> it should push and return Ok.
-            "",
-            "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-            Ok("/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
-        ),
-        (
-            // Last protocol is not p2p -> it should push and return Ok.
-            "/ip4/127.0.0.1",
-            "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-            Ok("/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
-        ),
-        (
-            // Last protocol is p2p and the contained peer matches the provided one -> it should do nothing and return Ok.
-            "/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-            "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-            Ok("/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
-        ),
-        (
-            // Last protocol is p2p but the contained peer does not match the provided one -> it should do nothing and return Err.
-            "/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-            "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-            Ok("/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
-        ),
-    ];
+mod multiaddr_with_p2p {
+    use libp2p_identity::PeerId;
+    use multiaddr::Multiaddr;
 
-    for (multiaddr_str, peer, expected) in TEST_DATA {
+    fn test_multiaddr_with_p2p(
+        multiaddr: &str,
+        peer: &str,
+        expected: std::result::Result<&str, &str>,
+    ) {
         let peer = peer.parse::<PeerId>().unwrap();
         let expected = expected
             .map(|a| a.parse::<Multiaddr>().unwrap())
             .map_err(|a| a.parse::<Multiaddr>().unwrap());
 
-        let mut multiaddr = multiaddr_str.parse::<Multiaddr>().unwrap();
+        let mut multiaddr = multiaddr.parse::<Multiaddr>().unwrap();
+        // Testing multiple time to validate idempotence.
         for _ in 0..3 {
             let result = multiaddr.with_p2p(peer);
             assert_eq!(result, expected);
             multiaddr = result.unwrap_or_else(|addr| addr);
         }
+    }
 
-        let result = Multiaddr::from_str_and_peer(multiaddr_str, peer);
-        assert_eq!(result.ok(), expected.ok());
+    #[test]
+    fn empty_multiaddr() {
+        // Multiaddr is empty -> it should push and return Ok.
+        test_multiaddr_with_p2p(
+            "",
+            "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+            Ok("/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
+        )
+    }
+    #[test]
+    fn non_p2p_terminated() {
+        // Last protocol is not p2p -> it should push and return Ok.
+        test_multiaddr_with_p2p(
+            "/ip4/127.0.0.1",
+            "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+            Ok("/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
+        )
+    }
+
+    #[test]
+    fn p2p_terminated_same_peer() {
+        // Last protocol is p2p and the contained peer matches the provided one -> it should do nothing and return Ok.
+        test_multiaddr_with_p2p(
+            "/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+            "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+            Ok("/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
+        )
+    }
+
+    #[test]
+    fn p2p_terminated_different_peer() {
+        // Last protocol is p2p but the contained peer does not match the provided one -> it should do nothing and return Err.
+        test_multiaddr_with_p2p(
+            "/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+            "QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            Err("/ip4/127.0.0.1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
+        )
     }
 }


### PR DESCRIPTION
## PR context

In order to have a uniformized usage of `multiaddr` with a `/p2p` suffix in the `rust-libp2p` repository, we are finding ourselves in need of utility method to easily ensure that a `multiaddr` is terminated by the `p2p` protocol for a given `PeerId`.

Our first thought was to only implement this method in our code base but since it is needed in several crates of ours and it could be useful to other people, we thought it could be a good idea to implement it directly on `Multiaddr`.

This is related to the following PR on the `rust-libp2p` repository: https://github.com/libp2p/rust-libp2p/pull/4596

## Implementation decisions

After some discussions, we (@thomaseizinger and myself) decided to implement a simple `with_p2p` function on `multiaddr`.

We studied a possibility to improve the `push` and `with` functions to be smart enough to not append the same protocol twice since it does not have any meaning and would result in an unusable `multiaddr` (except for some protocols like `certhash`). Although it would probably be a great idea and a great improvement, it would result in an important breaking API change since we would then need to return a `Result` (because a call to `with` or `push` could fail when trying to append the same protocol twice with a different content). Since this seems quite overkill for the current need we decided in the end that we leave the `push` and `with` function as it is for now.

We also studied the addition of a `from_str_and_peer` function, but seeing the resulting implementation, we decided it was not worth it to expand the public API surface for a one-line function.
```rust
pub fn from_str_and_peer(addr: &str, peer: PeerId) -> Result<Self> {
        addr.parse::<Self>()?.with_p2p(peer).map_err(|_| Error::InvalidMultiaddr)
}
```

