### PR TITLE
chore: Add doc auto cfg to show features in the documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,10 @@ bincode = "1"
 quickcheck = { version = "1.0.3", default-features = false }
 rand = "0.8.4"
 serde_json = "1.0"
+
+# Passing arguments to the docsrs builder in order to properly document cfg's.
+# More information: https://docs.rs/about/builds#cross-compiling
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+rustc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! Implementation of [multiaddr](https://github.com/multiformats/multiaddr) in Rust.
-#![cfg_attr(doc, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub use multihash;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! Implementation of [multiaddr](https://github.com/multiformats/multiaddr) in Rust.
+#![cfg_attr(doc, feature(doc_auto_cfg))]
 
 pub use multihash;
 


### PR DESCRIPTION
I aligned with rust-libp2p in that feature guarded items are now so documented.