### PR TITLE
chore: Add lint exception to make CI pass again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ bincode = "1"
 quickcheck = { version = "1.0.3", default-features = false }
 rand = "0.8.4"
 serde_json = "1.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }


### PR DESCRIPTION
In Rust 1.80 cfg checking was introduced in stable. Since we use `cfg(nightly)` in one test to check the number of variants, we need to tell the compiler that this is okay.

It might seem like a dirty fix, but it's a widely used workaround:
- [`cfg(nightly)` exception in Cargo.toml](https://github.com/search?q=cfg%28nightly%29+lang%3Atoml&type=code)
- [`cfg(nightly)` in Rust files](https://github.com/search?q=cfg%28nightly%29+lang%3Arust+&type=code)

It's also one of the suggested solutions by rust itself (and it's more efficient then using a build.rs file).

_Originally posted by @umgefahren in https://github.com/multiformats/rust-multiaddr/issues/110#issuecomment-2265472969_