### PR TITLE
Use `Bytes` to avoid double indirection with `Arc<Vec<u8>>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default = ["url"]
 [dependencies]
 arrayref = "0.3"
 byteorder = "1.5.0"
+bytes = "1.7.2"
 data-encoding = "2.6.0"
 multibase = "0.9.1"
 multihash = "0.19"


### PR DESCRIPTION
Due to inner mutation `Bytes` had to be used instead of `Arc<[u8]>`, which achieves the same result as before, but without double indirection that was used before. Public API is unchanged.

`BytesMut::from(Bytes)` attempts to reuse allocation just like `Arc::make_mut()` did before.

Fixes https://github.com/multiformats/rust-multiaddr/issues/117